### PR TITLE
Fixed: Spond.getGroup(uid) doesn't work

### DIFF
--- a/spond.py
+++ b/spond.py
@@ -32,6 +32,11 @@ class Spond():
     async def getGroup(self, uid):
         if not self.cookie:
             await self.login()
+        if not self.groups:
+            await self.getGroups()
+        for group in self.groups:
+            if group['id'] == uid:
+                return group
 
     async def getPerson(self, uid):
         if not self.cookie:


### PR DESCRIPTION
Bug fixe for #2.

Tested with this code:

```
async def main():
    s = spond.Spond(username=username, password=password)
    groups = await s.getGroups()
    sample_group_id = groups[0]['id']

    sample_group = await s.getGroup(sample_group_id)
    print(sample_group['name'])

    await s.clientsession.close()

loop = asyncio.get_event_loop()
loop.run_until_complete(main())
````