### PR TITLE
Make function names PEP-8 compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ password = 'Pa55worD'
 
 async def main():
     s = spond.Spond(username=username, password=password)
-    groups = await s.getGroups()
+    groups = await s.get_groups()
     for group in groups:
         print(group['name'])
     await s.clientsession.close()
@@ -37,21 +37,21 @@ loop.run_until_complete(main())
 
 ## Functions
 
-### getGroups()
+### get_groups()
 Gets all your group memberships and all members of those groups
 
-### getEvents([from_date])
+### get_events([from_date])
 Gets up to 100 events.
 
 Optional `from_date` parameter determines the earliest date from which events are returned.
 Pass a `datetime` to get earlier events, e.g.:
 ```
-events = await spond_session.getEvents(datetime.now() - timedelta(days=365))
+events = await spond_session.get_events(datetime.now() - timedelta(days=365))
 ```
 If omitted, returns events from today - 14 days.
 
 
-### getEventsBetween(from_date, to_date)
+### get_events_between(from_date, to_date)
 Gets up to 100 events.
 
 Required `from_date` and `to_date` parameters determines the earliest and latest date from which events are returned.
@@ -60,7 +60,7 @@ Both expect a `datetime` object, e.g.:
 from_date = datetime.now() - timedelta(days=30)
 to_date = datetime.now() + timedelta(days=30)
 
-events = await spond_session.getEventsBetween(from_date, to_date)
+events = await spond_session.get_events_between(from_date, to_date)
 ```
 Will return _up to_ 100 events starting from 30 days in the past until 30 days in the future.
 

--- a/attendance.py
+++ b/attendance.py
@@ -14,7 +14,7 @@ args = parser.parse_args()
 
 async def main():
     s = spond.Spond(username=username, password=password)
-    events = await s.getEventsBetween(args.f, args.t)
+    events = await s.get_events_between(args.f, args.t)
     
     if not os.path.exists('./exports'):
             os.makedirs('./exports')
@@ -27,28 +27,28 @@ async def main():
         
             spamwriter.writerow(["Start","End","Description","Name","Answer","Organizer"])
             for o in e['owners']:
-                person = await s.getPerson(o['id'])
+                person = await s.get_person(o['id'])
                 fullName = person['firstName'] + ' ' + person['lastName']
                 spamwriter.writerow([e['startTimestamp'], e['endTimestamp'], e['heading'], fullName, o['response'], "X"])
             if args.a is True:
                 for r in e['responses']['acceptedIds']:
-                    person = await s.getPerson(r)
+                    person = await s.get_person(r)
                     fullName = person['firstName'] + ' ' + person['lastName']
                     spamwriter.writerow([e['startTimestamp'], e['endTimestamp'], e['heading'], fullName, 'accepted'])
                 for r in e['responses']['declinedIds']:
-                    person = await s.getPerson(r)
+                    person = await s.get_person(r)
                     fullName = person['firstName'] + ' ' + person['lastName']
                     spamwriter.writerow([e['startTimestamp'], e['endTimestamp'], e['heading'], fullName, 'declined'])
                 for r in e['responses']['unansweredIds']:
-                    person = await s.getPerson(r)
+                    person = await s.get_person(r)
                     fullName = person['firstName'] + ' ' + person['lastName']
                     spamwriter.writerow([e['startTimestamp'], e['endTimestamp'], e['heading'], fullName, 'unanswered'])
                 for r in e['responses']['unconfirmedIds']:
-                    person = await s.getPerson(r)
+                    person = await s.get_person(r)
                     fullName = person['firstName'] + ' ' + person['lastName']
                     spamwriter.writerow([e['startTimestamp'], e['endTimestamp'], e['heading'], fullName, 'unconfirmed'])
                 for r in e['responses']['waitinglistIds']:
-                    person = await s.getPerson(r)
+                    person = await s.get_person(r)
                     fullName = person['firstName'] + ' ' + person['lastName']
                     spamwriter.writerow([e['startTimestamp'], e['endTimestamp'], e['heading'], fullName, 'waitinglist'])
                     

--- a/groups.py
+++ b/groups.py
@@ -12,7 +12,7 @@ if not os.path.exists('./exports'):
 
 async def main():
     s = spond.Spond(username=username, password=password)
-    groups = await s.getGroups()
+    groups = await s.get_groups()
     for group in groups:
         name = group['name']
         data = (json.dumps(group, indent=4, sort_keys=True))

--- a/ical.py
+++ b/ical.py
@@ -13,7 +13,7 @@ async def main():
     s = spond.Spond(username=username, password=password)
     c = Calendar()
     c.method = 'PUBLISH'
-    events = await s.getEvents()
+    events = await s.get_events()
     for event in events:
         e = Event()
         e.uid = event['id']

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -34,7 +34,7 @@ class Spond():
         self.chaturl = result['url']
         self.auth = result['auth']
 
-    async def getGroups(self):
+    async def get_groups(self):
         """
         Get all groups.
         Subject to authenticated user's access.
@@ -51,7 +51,7 @@ class Spond():
             self.groups = await r.json()
             return self.groups
 
-    async def getGroup(self, uid):
+    async def get_group(self, uid):
         """
         Get a group by unique ID.
         Subject to authenticated user's access.
@@ -69,12 +69,12 @@ class Spond():
         if not self.cookie:
             await self.login()
         if not self.groups:
-            await self.getGroups()
+            await self.get_groups()
         for group in self.groups:
             if group['id'] == uid:
                 return group
 
-    async def getPerson(self, user):
+    async def get_person(self, user):
         """
         Get a member or guardian by matching various identifiers.
         Subject to authenticated user's access.
@@ -93,7 +93,7 @@ class Spond():
         if not self.cookie:
             await self.login()
         if not self.groups:
-            await self.getGroups()
+            await self.get_groups()
         for group in self.groups:
             for member in group['members']:
                 if member['id'] == user or ('email' in member and member['email']) == user or member['firstName'] + " " + member['lastName'] == user or ( 'profile' in member and member['profile']['id'] == user):
@@ -103,7 +103,7 @@ class Spond():
                         if guardian['id'] == user or ('email' in guardian and guardian['email']) == user or guardian['firstName'] + " " + guardian['lastName'] == user or ( 'profile' in guardian and guardian['profile']['id'] == user):
                             return guardian
 
-    async def getMessages(self):
+    async def get_messages(self):
         if not self.cookie:
             await self.login()
         url = self.chaturl + "/chats/?max=10"
@@ -112,7 +112,7 @@ class Spond():
             return await r.json()
 
 
-    async def sendMessage(self, recipient, text):
+    async def send_message(self, recipient, text):
         if not self.cookie:
             await self.login()
         url = self.chaturl + "/messages"
@@ -122,7 +122,7 @@ class Spond():
         print(r)
         return await r.json()
 
-    async def getEvents(self, from_date = None):
+    async def get_events(self, from_date = None):
         """
         Get up to 100 events up to present.
         Subject to authenticated user's access.
@@ -148,7 +148,7 @@ class Spond():
             self.events = await r.json()
             return self.events
 
-    async def getEventsBetween(self, from_date, to_date, max_events=100):
+    async def get_events_between(self, from_date, to_date, max_events=100):
         """
         Get events between two datetimes.
         Subject to authenticated user's access.
@@ -181,7 +181,7 @@ class Spond():
             self.events = await r.json()
             return self.events
 
-    async def getEvent(self, uid):
+    async def get_event(self, uid):
         """
         Get an event by unique ID.
         Subject to authenticated user's access.
@@ -199,7 +199,7 @@ class Spond():
         if not self.cookie:
             await self.login()
         if not self.events:
-            await self.getEvents()
+            await self.get_events()
         for event in self.events:
             if event['id'] == uid:
                 return event


### PR DESCRIPTION
Use PEP8 function name convention, e.g. `get_events_between()` instead of `getEventsBetween`