### PR TITLE
Require Python >=3.7.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+python_requires = ">=3.7"


### PR DESCRIPTION
Re #26 .

3.7 is curently the latest supported version.
Seems to work OK on 3.7.9, which is the latest readily available installer.

I'm not up to date with best practice on whwre to specify this, so hope `pyproject.toml` is OK.