### PR TITLE
54 dont install unnecessary dependencies in ci script

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Install project
-      run: poetry install
+      run: poetry install --without dev
     - name: Test with pytest
       run: |
         source $VENV

--- a/poetry.lock
+++ b/poetry.lock
@@ -763,4 +763,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "2bf5846bd4eeb13397979a62600a7f480b86c325570620d3729bbcabf342c704"
+content-hash = "2e6a8fb9ba20de93f2d0a8ef090e8932acfde46ba40e18ee89a36bdcf450ea63"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ aiohttp = "^3.8.3"
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
 isort = "^5.11.4"
+
+[tool.poetry.group.test.dependencies]
 pytest = "^7.2.0"
 
 [tool.black]


### PR DESCRIPTION
Works, but time saved isn't as significant as I expected. 

Note that this has no impact on default `poetry install` for development, which installs both `dev` and `test` groups.