### PR TITLE
Enforce `isort` in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,9 @@ jobs:
         virtualenvs-in-project: true
     - name: Install project
       run: poetry install
+    - name: Lint with isort
+      # by default: exit with error if the code is not properly sorted; show diffs
+      uses: isort/isort-action@master
     - name: Test with pytest
       run: |
         source $VENV

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Install project
-      run: poetry install --without dev
+      run: poetry install
     - name: Test with pytest
       run: |
         source $VENV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ aiohttp = "^3.8.3"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.1.0"
-isort = "^5.11.4"
+isort = "^5.12.0"
 pytest = "^7.2.2"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ target-version = ['py38']
 
 [tool.isort]
 profile = "black"
+src_paths = ["spond", "tests"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ aiohttp = "^3.8.3"
 [tool.poetry.group.dev.dependencies]
 black = "^23.1.0"
 isort = "^5.11.4"
-
-[tool.poetry.group.test.dependencies]
 pytest = "^7.2.2"
 
 [tool.black]


### PR DESCRIPTION
Trying to ignore example scripts, but `isort` config in https://github.com/Olen/Spond/pull/79/commits/8cd6fc8f8d38950bb0fd3c189171202942cc8da6
doesn't seem to be applied...