### PR TITLE
Add GitHub dependabot to handle package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@ updates:
   - package-ecosystem: "pip"  # also supports Poetry
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions" # only supports updates using the GitHub repository syntax, such as actions/checkout@v3
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  - package-ecosystem: "pip"  # also supports Poetry
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "github-actions" # only supports updates using the GitHub repository syntax, such as actions/checkout@v3
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Dependabot script to raise PRs to update outdated packages (and Github Actions that follow GitHub repository syntax) monthly.

@Olen I can adjust to e.g. weekly if you prefer.

This won't do anything until enabled in the GitHub interface; I'll note that in #87.