### PR TITLE
fix(authentication): switch authentication mode

### DIFF
--- a/spond/spond.py
+++ b/spond/spond.py
@@ -376,7 +376,8 @@ class Spond:
                 base_event[key] = updates[key]
 
         data = dict(base_event)
-        headers = {"content-type": "application/json;charset=utf-8"}
-        async with self.clientsession.post(url, json=data, headers=headers) as r:
+        async with self.clientsession.post(
+            url, json=data, headers=self.auth_headers
+        ) as r:
             self.events_update = await r.json()
             return self.events


### PR DESCRIPTION
Description:
- function fails with  `{'message': 'Not authenticated'}`
- move to different headers and authentication solves the problem

Steps to reproduce:
- Demo code, modify uid_to_update, username and password

````
import asyncio

from config import password, username
from spond import spond

async def main():
    s = spond.Spond(username=username, password=password)
    uid_to_update = "xxxxxxxxxxx"
    updates = {
        'heading': "print",
        'description': "New Description with changes",
        # Add other updates as needed
    }

    try:
        await s.update_event(uid_to_update, updates)
        print("Event updated successfully.")
    except Exception as e:
        print(f"Failed to update event: {e}")

    await s.clientsession.close()

loop = asyncio.new_event_loop()
asyncio.set_event_loop(loop)
asyncio.run(main())

````

Expected behavier:
- authentication is successful