### PR TITLE
Fix: CI: isort GitHub action doesn't report expected issues 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,10 +32,12 @@ jobs:
     - name: Install project
       run: poetry install
     - name: Lint imports with isort
-      # By default: exit with error if imports are not properly sorted
-      uses: isort/isort-action@master
-      with:
-        configuration: profile = black
+      # Use command line due to bugs/doc gaps with official `isort/isort-action`.
+      # Exit with error if the code is not properly formatted; show diffs;
+      # `black` compatibility
+      run: |
+        source $VENV
+        isort . --check-only --diff --profile black
     - name: Lint with black
       # by default: exit with error if the code is not properly formatted; show diffs
       uses: psf/black@stable

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,12 +32,18 @@ jobs:
     - name: Install project
       run: poetry install
     - name: Lint imports with isort
-      # Use command line due to bugs/doc gaps with official `isort/isort-action`.
+      # Use command line due to bugs/docs gaps with official `isort/isort-action`.
       # Exit with error if the code is not properly formatted; show diffs;
-      # `black` compatibility
+      # `black` compatibility.
+      # Only target files in `spond` and `test` due to unreliable behaviour on files in
+      # root directory.
+      # Diffs reported for these files should be the same as fixes made by running
+      # `isort .` in the root project folder, which picks up config from
+      # `pyproject.toml`.
       run: |
         source $VENV
-        isort . --check-only --diff --profile black
+        isort spond --check-only --diff --profile black
+        isort tests --check-only --diff --profile black
     - name: Lint with black
       # by default: exit with error if the code is not properly formatted; show diffs
       uses: psf/black@stable


### PR DESCRIPTION
I did misconfigure the black compatibility for the official isort action originally, but doesn't seem to be any documentation on how to do it correctly, and in any case it doesn't show diffs like it's supposed to (raised [isort-action #90](https://github.com/isort/isort-action/issues/90)). So I've re-implemented using command-line interface.

It should really be configured to take config from `pyproject.toml`, but that's a possible enhancement; this is restoring expected functionality.

NB isort checks are expected to fail on this PR until existing codebase has corrected isort rule run on it. I think is clearest if I do this in another PR. Will do a dry run in my own fork first...