### PR TITLE
Lint existing codebase with isort + black to allow fixed CI in #116 to pass checks

### DIFF
--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-
 from spond.spond import Spond
 
 MOCK_USERNAME, MOCK_PASSWORD = "MOCK_USERNAME", "MOCK_PASSWORD"


### PR DESCRIPTION
NB 1: this does not affect files in root folder, only `spond` and `test`. But that seems to be documented behaviour given code structure, and use of `pyproject.toml` for configuration.

Files in root folder can be targeted in CI/fixed later.

NB 2: ran `isort . --show-config` first to check that `profile = "black"` is picked up from `pyproject.toml` OK.

NB 3: I've done a dry run in my own fork. 