### PR TITLE
feat: add type annotations for function args and returns  in `spond\`, where they are unambiguous and don't conflict with docstrings

### DIFF
--- a/spond/base.py
+++ b/spond/base.py
@@ -8,7 +8,7 @@ class AuthenticationError(Exception):
 
 
 class _SpondBase(ABC):
-    def __init__(self, username, password, api_url) -> None:
+    def __init__(self, username: str, password: str, api_url: str) -> None:
         self.username = username
         self.password = password
         self.api_url = api_url

--- a/spond/base.py
+++ b/spond/base.py
@@ -8,7 +8,7 @@ class AuthenticationError(Exception):
 
 
 class _SpondBase(ABC):
-    def __init__(self, username, password, api_url):
+    def __init__(self, username, password, api_url) -> None:
         self.username = username
         self.password = password
         self.api_url = api_url
@@ -16,7 +16,7 @@ class _SpondBase(ABC):
         self.token = None
 
     @property
-    def auth_headers(self):
+    def auth_headers(self) -> dict:
         return {
             "content-type": "application/json",
             "Authorization": f"Bearer {self.token}",
@@ -34,7 +34,7 @@ class _SpondBase(ABC):
 
         return wrapper
 
-    async def login(self):
+    async def login(self) -> None:
         login_url = f"{self.api_url}login"
         data = {"email": self.username, "password": self.password}
         async with self.clientsession.post(login_url, json=data) as r:

--- a/spond/club.py
+++ b/spond/club.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from .base import _SpondBase
 
@@ -11,7 +11,7 @@ class SpondClub(_SpondBase):
     @_SpondBase.require_authentication
     async def get_transactions(
         self, club_id: str, skip: Optional[int] = None, max_items: int = 100
-    ):
+    ) -> List[dict]:
         """
         Retrieves a list of transactions/payments for a specified club.
 

--- a/spond/club.py
+++ b/spond/club.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import Optional
 
 from .base import _SpondBase
 
@@ -11,7 +13,7 @@ class SpondClub(_SpondBase):
     @_SpondBase.require_authentication
     async def get_transactions(
         self, club_id: str, skip: Optional[int] = None, max_items: int = 100
-    ) -> List[dict]:
+    ) -> list[dict]:
         """
         Retrieves a list of transactions/payments for a specified club.
 

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -43,7 +43,7 @@ class Spond(_SpondBase):
             return self.groups
 
     @_SpondBase.require_authentication
-    async def get_group(self, uid) -> dict:
+    async def get_group(self, uid: str) -> dict:
         """
         Get a group by unique ID.
         Subject to authenticated user's access.
@@ -72,7 +72,7 @@ class Spond(_SpondBase):
         raise IndexError(errmsg)
 
     @_SpondBase.require_authentication
-    async def get_person(self, user) -> dict:
+    async def get_person(self, user: str) -> dict:
         """
         Get a member or guardian by matching various identifiers.
         Subject to authenticated user's access.
@@ -122,7 +122,7 @@ class Spond(_SpondBase):
             return await r.json()
 
     @_SpondBase.require_authentication
-    async def _continue_chat(self, chat_id, text):
+    async def _continue_chat(self, chat_id: str, text: str):
         """
         Send a given text in an existing given chat.
         Subject to authenticated user's access.
@@ -148,7 +148,7 @@ class Spond(_SpondBase):
         return await r.json()
 
     @_SpondBase.require_authentication
-    async def send_message(self, text, user=None, group_uid=None, chat_id=None):
+    async def send_message(self, text: str, user=None, group_uid=None, chat_id=None):
         """
         Start a new chat or continue an existing one.
 
@@ -275,7 +275,7 @@ class Spond(_SpondBase):
             return self.events
 
     @_SpondBase.require_authentication
-    async def get_event(self, uid) -> dict:
+    async def get_event(self, uid: str) -> dict:
         """
         Get an event by unique ID.
         Subject to authenticated user's access.
@@ -303,7 +303,7 @@ class Spond(_SpondBase):
         raise IndexError(errmsg)
 
     @_SpondBase.require_authentication
-    async def update_event(self, uid, updates: dict):
+    async def update_event(self, uid: str, updates: dict):
         """
         Updates an existing event.
 

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
+
+from __future__ import annotations
+
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from .base import _SpondBase
 
@@ -27,7 +30,7 @@ class Spond(_SpondBase):
         self.auth = result["auth"]
 
     @_SpondBase.require_authentication
-    async def get_groups(self) -> List[dict]:
+    async def get_groups(self) -> list[dict]:
         """
         Get all groups.
         Subject to authenticated user's access.
@@ -114,7 +117,7 @@ class Spond(_SpondBase):
         raise IndexError
 
     @_SpondBase.require_authentication
-    async def get_messages(self) -> List[dict]:
+    async def get_messages(self) -> list[dict]:
         if not self.auth:
             await self.login_chat()
         url = f"{self.chat_url}/chats/?max=10"
@@ -208,7 +211,7 @@ class Spond(_SpondBase):
         max_start: Optional[datetime] = None,
         min_start: Optional[datetime] = None,
         max_events: int = 100,
-    ) -> List[dict]:
+    ) -> list[dict]:
         """
         Get events.
         Subject to authenticated user's access.

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -19,7 +19,7 @@ class Spond(_SpondBase):
         self.groups = None
         self.events = None
 
-    async def login_chat(self):
+    async def login_chat(self) -> None:
         api_chat_url = f"{self.api_url}chat"
         r = await self.clientsession.post(api_chat_url, headers=self.auth_headers)
         result = await r.json()
@@ -27,7 +27,7 @@ class Spond(_SpondBase):
         self.auth = result["auth"]
 
     @_SpondBase.require_authentication
-    async def get_groups(self):
+    async def get_groups(self) -> List[dict]:
         """
         Get all groups.
         Subject to authenticated user's access.
@@ -114,7 +114,7 @@ class Spond(_SpondBase):
         raise IndexError
 
     @_SpondBase.require_authentication
-    async def get_messages(self):
+    async def get_messages(self) -> List[dict]:
         if not self.auth:
             await self.login_chat()
         url = f"{self.chat_url}/chats/?max=10"

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -327,7 +327,7 @@ class Spond(_SpondBase):
 
         url = f"{self.api_url}sponds/{uid}"
 
-        base_event = {
+        base_event: dict = {
             "heading": None,
             "description": None,
             "spondType": "EVENT",


### PR DESCRIPTION
This PR has no run-time impact, and purposely avoids tackling any more complex typing issues (which  could be considered bugs/not-as-documented).