### PR TITLE
Changed: raise `KeyError` instead of `IndexError` for all failed lookup methods

### DIFF
--- a/spond/spond.py
+++ b/spond/spond.py
@@ -61,8 +61,7 @@ class Spond(_SpondBase):
 
         Raises
         ------
-        IndexError if no group is matched.
-
+        KeyError if no group is matched.
         """
 
         if not self.groups:
@@ -70,8 +69,8 @@ class Spond(_SpondBase):
         for group in self.groups:
             if group["id"] == uid:
                 return group
-        errmsg = f"No group with id='{uid}'"
-        raise IndexError(errmsg)
+        errmsg = f"No group with id='{uid}'."
+        raise KeyError(errmsg)
 
     @_SpondBase.require_authentication
     async def get_person(self, user: str) -> dict:
@@ -88,6 +87,10 @@ class Spond(_SpondBase):
         Returns
         -------
         Member or guardian's details.
+
+        Raises
+        ------
+        KeyError if no person is matched.
         """
         if not self.groups:
             await self.get_groups()
@@ -113,7 +116,8 @@ class Spond(_SpondBase):
                             )
                         ):
                             return guardian
-        raise IndexError
+        errmsg = f"No person matched with identifier '{user}'."
+        raise KeyError(errmsg)
 
     @_SpondBase.require_authentication
     async def get_messages(self) -> list[dict]:
@@ -299,7 +303,7 @@ class Spond(_SpondBase):
 
         Raises
         ------
-        IndexError if no event is matched.
+        KeyError if no event is matched.
 
         """
         if not self.events:
@@ -307,8 +311,8 @@ class Spond(_SpondBase):
         for event in self.events:
             if event["id"] == uid:
                 return event
-        errmsg = f"No event with id='{uid}'"
-        raise IndexError(errmsg)
+        errmsg = f"No event with id='{uid}'."
+        raise KeyError(errmsg)
 
     @_SpondBase.require_authentication
     async def update_event(self, uid: str, updates: dict):

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -80,25 +80,25 @@ async def test_get_event__happy_path(mock_events, mock_token):
 
 @pytest.mark.asyncio
 async def test_get_event__no_match_raises_exception(mock_events, mock_token):
-    """Test that a non-matched `id` raises IndexError."""
+    """Test that a non-matched `id` raises KeyError."""
 
     s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
     s.events = mock_events
     s.token = mock_token
 
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         await s.get_event("ID3")
 
 
 @pytest.mark.asyncio
 async def test_get_event__blank_id_match_raises_exception(mock_events, mock_token):
-    """Test that a blank `id` raises IndexError."""
+    """Test that a blank `id` raises KeyError."""
 
     s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
     s.events = mock_events
     s.token = mock_token
 
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         await s.get_event("")
 
 
@@ -119,25 +119,25 @@ async def test_get_group__happy_path(mock_groups, mock_token):
 
 @pytest.mark.asyncio
 async def test_get_group__no_match_raises_exception(mock_groups, mock_token):
-    """Test that a non-matched `id` raises IndexError."""
+    """Test that a non-matched `id` raises KeyError."""
 
     s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
     s.groups = mock_groups
     s.token = mock_token
 
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         await s.get_group("ID3")
 
 
 @pytest.mark.asyncio
 async def test_get_group__blank_id_raises_exception(mock_groups, mock_token):
-    """Test that a blank `id` raises IndexError."""
+    """Test that a blank `id` raises KeyError."""
 
     s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
     s.groups = mock_groups
     s.token = mock_token
 
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         await s.get_group("")
 
 


### PR DESCRIPTION
For `get_person()`, also make error message more meaningful and add 'Raises' to docstring.