### PR TITLE
Add type hints for `Spond` and `SpondClub` `__init__()` methods.

### DIFF
--- a/spond/club.py
+++ b/spond/club.py
@@ -6,7 +6,7 @@ from .base import _SpondBase
 
 
 class SpondClub(_SpondBase):
-    def __init__(self, username, password):
+    def __init__(self, username: str, password: str) -> None:
         super().__init__(username, password, "https://api.spond.com/club/v1/")
         self.transactions = None
 

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -14,7 +14,7 @@ class Spond(_SpondBase):
 
     DT_FORMAT = "%Y-%m-%dT00:00:00.000Z"
 
-    def __init__(self, username, password):
+    def __init__(self, username: str, password: str) -> None:
         super().__init__(username, password, "https://api.spond.com/core/v1/")
         self.chat_url = None
         self.auth = None


### PR DESCRIPTION
This is a key 'missing piece' that should enable static type-checkers (e.g. mypy or IDE tools) to analyse the code fully, and help resolve more complex issues.