### PR TITLE
`Spond.get_messages`: add `max_chats` parameter (default 100) and populate `Spond.messages`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Optional parameters allow filtering by start and end datetimes, group and subgro
 ### get_person()
 Get a member's details.
 
-### get_messages()
-Get all your messages.
+### get_messages(max_chats=100)
+Get chats, limited to 100 by default.
+Optional parameter allows more events to be returned.
 
 ### send_message(text, user=None, group_uid=None, chat_id=None)
 Send a message with content `text`.

--- a/manual_test_functions.py
+++ b/manual_test_functions.py
@@ -13,6 +13,10 @@ from spond import club, spond
 
 DUMMY_ID = "DUMMY_ID"
 
+MAX_EVENTS = 10
+MAX_CHATS = 10
+MAX_TRANSACTIONS = 10
+
 
 async def main() -> None:
     s = spond.Spond(username=username, password=password)
@@ -27,19 +31,19 @@ async def main() -> None:
 
     # EVENTS
 
-    print("\nGetting up to 10 events...")
-    events = await s.get_events(max_events=10)
+    print(f"\nGetting up to {MAX_EVENTS} events...")
+    events = await s.get_events(max_events=MAX_EVENTS)
     print(f"{len(events)} events:")
     for i, event in enumerate(events):
         print(f"[{i}] {_event_summary(event)}")
 
-    # MESSAGES
+    # CHATS (MESSAGES)
 
-    print("\nGetting up to 10 messages...")
-    messages = await s.get_messages()
-    print(f"{len(messages)} messages:")
-    for i, message in enumerate(messages):
-        print(f"[{i}] {_message_summary(message)}")
+    print(f"\nGetting up to {MAX_CHATS} chats...")
+    messages = await s.get_messages(max_chats=MAX_CHATS)
+    print(f"{len(messages)} chats:")
+    for i, chat in enumerate(messages):
+        print(f"[{i}] {_message_summary(chat)}")
 
     # ATTENDANCE EXPORT
 
@@ -56,8 +60,10 @@ async def main() -> None:
 
     # SPOND CLUB
     sc = club.SpondClub(username=username, password=password)
-    print("\nGetting up to 10 transactions...")
-    transactions = await sc.get_transactions(club_id=club_id, max_items=10)
+    print(f"\nGetting up to {MAX_TRANSACTIONS} transactions...")
+    transactions = await sc.get_transactions(
+        club_id=club_id, max_items=MAX_TRANSACTIONS
+    )
     print(f"{len(transactions)} transactions:")
     for i, t in enumerate(transactions):
         print(f"[{i}] {_transaction_summary(t)}")

--- a/manual_test_functions.py
+++ b/manual_test_functions.py
@@ -1,6 +1,6 @@
 """Use Spond 'get' functions to summarise available data.
 
-Intended as a simple end-to-end test for assurance when making changes, where there are s
+Intended as a simple end-to-end test for assurance when making changes, where there are
 gaps in test suite coverage.
 
 Doesn't yet use `get_person(user)` or any `send_`, `update_` methods."""
@@ -40,10 +40,10 @@ async def main() -> None:
     # CHATS (MESSAGES)
 
     print(f"\nGetting up to {MAX_CHATS} chats...")
-    messages = await s.get_messages(max_chats=MAX_CHATS)
-    print(f"{len(messages)} chats:")
-    for i, chat in enumerate(messages):
-        print(f"[{i}] {_message_summary(chat)}")
+    chats = await s.get_messages(max_chats=MAX_CHATS)
+    print(f"{len(chats)} chats:")
+    for i, chat in enumerate(chats):
+        print(f"[{i}] {_chat_summary(chat)}")
 
     # ATTENDANCE EXPORT
 
@@ -82,11 +82,12 @@ def _event_summary(event) -> str:
     )
 
 
-def _message_summary(message) -> str:
+def _chat_summary(chat) -> str:
+    msg_text = chat["message"].get("text", "")
     return (
-        f"id='{message['id']}', "
-        f"timestamp='{message['message']['timestamp']}', "
-        f"text={_abbreviate(message['message']['text'] if message['message'].get('text') else '', length=64)}, "
+        f"id='{chat['id']}', "
+        f"timestamp='{chat['message']['timestamp']}', "
+        f"text={_abbreviate(msg_text, length=64)}"
     )
 
 

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -32,15 +32,16 @@ class Spond(_SpondBase):
         self.auth = result["auth"]
 
     @_SpondBase.require_authentication
-    async def get_groups(self) -> list[dict]:
+    async def get_groups(self) -> Optional[list[dict]]:
         """
-        Get all groups.
-        Subject to authenticated user's access.
+        Retrieve all groups, subject to authenticated user's access.
 
         Returns
         -------
-        list of dict
-            Groups; each group is a dict.
+        list[dict] or None
+            A list of groups, each represented as a dictionary, or None if no groups
+            are available.
+
         """
         url = f"{self.api_url}groups/"
         async with self.clientsession.get(url, headers=self.auth_headers) as r:
@@ -116,7 +117,17 @@ class Spond(_SpondBase):
         raise KeyError(errmsg)
 
     @_SpondBase.require_authentication
-    async def get_messages(self) -> list[dict]:
+    async def get_messages(self) -> Optional[list[dict]]:
+        """
+        Retrieve messages (chats).
+
+        Returns
+        -------
+        list[dict] or None
+            A list of chats, each represented as a dictionary, or None if no chats
+            are available.
+
+        """
         if not self.auth:
             await self.login_chat()
         url = f"{self.chat_url}/chats/?max=10"
@@ -216,10 +227,9 @@ class Spond(_SpondBase):
         max_start: Optional[datetime] = None,
         min_start: Optional[datetime] = None,
         max_events: int = 100,
-    ) -> list[dict]:
+    ) -> Optional[list[dict]]:
         """
-        Get events.
-        Subject to authenticated user's access.
+        Retrieve events.
 
         Parameters
         ----------
@@ -255,8 +265,10 @@ class Spond(_SpondBase):
 
         Returns
         -------
-        list of dict
-            Events; each event is a dict.
+        list[dict] or None
+            A list of events, each represented as a dictionary, or None if no events
+            are available.
+
         """
         url = f"{self.api_url}sponds/"
         params = {


### PR DESCRIPTION
This PR:

- Re #144: Adds an optional `max_chats` parameter to `Spond.get_messages()`; defaults to 100. Previously up to 10 chats were returned.
- Re #145: #Changes `Spond.get_messages()` so it populates `Spond.messages` in line with other `get_{multiple_items_from_api}()` methods.
- Updates `manual_test_functions` to use the new parameter (and extracts all `max` values to constants)
- Where possible, uses the term 'chats' instead of `messages' which is more accurate (a chat can contain many messages) but *not* to the extent of changing the API - that can be discussed later.