### PR TITLE
feat: replace `isort` and `black` for import sorting + formatting, re…

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,23 +30,19 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Install project
-      run: poetry install
-    - name: Lint imports with isort
-      # Use command line due to bugs/docs gaps with official `isort/isort-action`.
-      # Exit with error if the code is not properly formatted; show diffs;
-      # `black` compatibility.
-      # Only target files in `spond` and `test` due to unreliable behaviour on files in
-      # root directory.
-      # Diffs reported for these files should be the same as fixes made by running
-      # `isort .` in the root project folder, which picks up config from
+      # Don't install dependencies that are handled within actions
+      run: poetry install --without dev
+    - name: Lint with ruff
+      # By default, exit with error if rule violations, report issues.
+      # Equivalent to `ruff check`. Picks up config from `pyproject.toml`.
+      uses: chartboost/ruff-action@v1
+    - name: Check format with ruff
+      # By default, exit with error if the code is not properly formatted.
+      # Equivalent to `ruff format --check --diff`. Picks up config from
       # `pyproject.toml`.
-      run: |
-        source $VENV
-        isort spond --check-only --diff --profile black
-        isort tests --check-only --diff --profile black
-    - name: Lint with black
-      # by default: exit with error if the code is not properly formatted; show diffs
-      uses: psf/black@stable
+      uses: chartboost/ruff-action@v1
+      with:
+        args: format --check --diff
     - name: Test with pytest
       run: |
         source $VENV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,18 +11,19 @@ repository = 'https://github.com/Olen/Spond'
 python = "^3.8"
 aiohttp = "^3.8.5"
 
-[tool.poetry.group.dev.dependencies]
-black = "^24.4.0"
-isort = "^5.11.4"
+[tool.poetry.group.dev.dependencies]  # not required by CI
+ruff = "^0.5.5"
+
+[tool.poetry.group.test.dependencies]
 pytest = "^8.1.1"
 pytest-asyncio = "^0.23.6"
 
-[tool.black]
-line-length = 88
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+[tool.ruff]
+target-version = "py38"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+# Enable only isort rules
+select = ["I"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
…plicating current behaviour, including CI.

Notes:

- Ruff takes a single value for `target-version` - the minimum Python version that should be supported

- Use `ruff check --fix` instead of `isort .` at CLI

- Use `ruff format` instead of `black .` at CLI