### PR TITLE
Use `ruff` instead of `isort` and `black` and enforce basic linting

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,23 +30,19 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Install project
-      run: poetry install
-    - name: Lint imports with isort
-      # Use command line due to bugs/docs gaps with official `isort/isort-action`.
-      # Exit with error if the code is not properly formatted; show diffs;
-      # `black` compatibility.
-      # Only target files in `spond` and `test` due to unreliable behaviour on files in
-      # root directory.
-      # Diffs reported for these files should be the same as fixes made by running
-      # `isort .` in the root project folder, which picks up config from
+      # Don't install dependencies that are handled within actions
+      run: poetry install --without dev-not-ci
+    - name: Lint with ruff
+      # By default, exit with error if rule violations, report issues.
+      # Equivalent to `ruff check`. Picks up config from `pyproject.toml`.
+      uses: astral-sh/ruff-action@v3
+    - name: Check format with ruff
+      # By default, exit with error if the code is not properly formatted.
+      # Equivalent to `ruff format --check --diff`. Picks up config from
       # `pyproject.toml`.
-      run: |
-        source $VENV
-        isort spond --check-only --diff --profile black
-        isort tests --check-only --diff --profile black
-    - name: Lint with black
-      # by default: exit with error if the code is not properly formatted; show diffs
-      uses: psf/black@stable
+      uses: astral-sh/ruff-action@v3
+      with:
+        args: "format --check --diff"
     - name: Test with pytest
       run: |
         source $VENV

--- a/attendance.py
+++ b/attendance.py
@@ -6,6 +6,7 @@ import re
 from datetime import date
 
 from config import password, username
+
 from spond import spond
 
 parser = argparse.ArgumentParser(

--- a/groups.py
+++ b/groups.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from config import password, username
+
 from spond import spond
 
 if not os.path.exists("./exports"):

--- a/ical.py
+++ b/ical.py
@@ -30,7 +30,7 @@ async def main():
         if "cancelled" in event and event["cancelled"]:
             e.status = "Cancelled"
         if "location" in event:
-            e.location = f'{event["location"].get("feature")}, {event["location"].get("address")}'
+            e.location = f"{event['location'].get('feature')}, {event['location'].get('address')}"
         c.events.add(e)
     with open(ics_file, "w") as out_file:
         out_file.writelines(c)

--- a/ical.py
+++ b/ical.py
@@ -3,9 +3,9 @@
 import asyncio
 import os
 
+from config import password, username
 from ics import Calendar, Event
 
-from config import password, username
 from spond import spond
 
 if not os.path.exists("./exports"):

--- a/manual_test_functions.py
+++ b/manual_test_functions.py
@@ -9,6 +9,7 @@ import asyncio
 import tempfile
 
 from config import club_id, password, username
+
 from spond import JSONDict, club, spond
 
 DUMMY_ID = "DUMMY_ID"

--- a/manual_test_functions.py
+++ b/manual_test_functions.py
@@ -71,7 +71,7 @@ async def main() -> None:
 
 
 def _group_summary(group: JSONDict) -> str:
-    return f"id='{group['id']}', " f"name='{group['name']}'"
+    return f"id='{group['id']}', name='{group['name']}'"
 
 
 def _event_summary(event: JSONDict) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,13 @@ target-version = "py39"  # Ruff doesn't yet infer this from [tool.poetry.depende
 
 [tool.ruff.lint]
 select = [
+    "E",  # pycodestyle
+    "F",  # Pyflakes
     "I",  # isort
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    "E501",  # Line too long: needs code refactors first
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,17 +12,21 @@ python = "^3.9"
 aiohttp = "^3.8.5"
 
 [tool.poetry.group.dev.dependencies]
-black = "^24.10.0"
-isort = "^5.11.4"
 pytest = "^8.1.1"
 pytest-asyncio = "^0.23.6"
 
-[tool.black]
-line-length = 88
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+[tool.poetry.group.dev-not-ci.dependencies]
+# Group for dev dependencies which don't require explicit installation in CI,
+# as they are handled by GitHub actions.
+ruff = "^0.9.6"
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+target-version = "py39"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
+
+[tool.ruff.lint]
+select = [
+    "I",  # isort
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,15 @@ ignore = [
     "E501",  # Line too long: needs code refactors first
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# Don't try to sort imports in example files, as non-existent `config` module causes
+# issues in CI
+"attendance.py" = ["I001"]
+"groups.py" = ["I001"]
+"ical.py" = ["I001"]
+"manual_test_functions.py" = ["I001"]
+"transactions.py" = ["I001"]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/spond/club.py
+++ b/spond/club.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 
 class SpondClub(_SpondBase):
-
     _API_BASE_URL: ClassVar = "https://api.spond.com/club/v1/"
 
     def __init__(self, username: str, password: str) -> None:

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 
 class Spond(_SpondBase):
-
     _API_BASE_URL: ClassVar = "https://api.spond.com/core/v1/"
     _DT_FORMAT: ClassVar = "%Y-%m-%dT00:00:00.000Z"
     _EVENT_TEMPLATE: ClassVar = _EVENT_TEMPLATE

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -41,7 +41,6 @@ def mock_payload():
 
 
 class TestEventMethods:
-
     @pytest.fixture
     def mock_events(self) -> list[JSONDict]:
         """Mock a minimal list of events."""

--- a/transactions.py
+++ b/transactions.py
@@ -4,6 +4,7 @@ import csv
 from pathlib import Path
 
 from config import club_id, password, username
+
 from spond.club import SpondClub
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
This PR effectively replaces `isort` + `black` with `ruff check`/`ruff format`, including in CI.

- It enforces `ruff`'s formatting rules - these differ slightly from `black`'s, but I don't think it's worth worrying about that.
- It also enforces a few basic linting rules that the code already meets (a subset of those suggested at https://docs.astral.sh/ruff/linter/#rule-selection). These can be extended in future.

How to use at CLI when developing:

- Use `ruff check --fix` to autolint, instead of `isort .` to just sort imports
- Use `ruff format` instead of `black .`