### PR TITLE
Add support for Python 3.13, drop support for Python 3.8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Check out repository

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Check out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = 'README.md'
 repository = 'https://github.com/Olen/Spond'
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 aiohttp = "^3.8.5"
 
 [tool.poetry.group.dev.dependencies]
@@ -19,7 +19,7 @@ pytest-asyncio = "^0.23.6"
 
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.9"
 aiohttp = "^3.8.5"
 
 [tool.poetry.group.dev.dependencies]
-black = "^24.4.0"
+black = "^24.10.0"
 isort = "^5.11.4"
 pytest = "^8.1.1"
 pytest-asyncio = "^0.23.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ pytest-asyncio = "^0.23.6"
 
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This PR:
- Adds newly released Python 3.13 to CI matrix and to `black` `target-versions`
- Removes end-of-life Python 3.8 from CI matrix and from `black` `target-versions`. This is primarily because latest `black` no longer supports 3.8
- Bumps dev-dep `black` to latest to ensure same behaviour in dev and CI 

I've done a quick check and there don't appear to be any obvious code upgrades to be made by dropping 3.8.

3.9 did introduce the `|` Union operator, but that's already used in the code via `__future__ import annotations`.
