### PR TITLE
Fix: attendance.py example script exits with error if --from or --to params are used

### DIFF
--- a/attendance.py
+++ b/attendance.py
@@ -32,7 +32,7 @@ args = parser.parse_args()
 
 async def main():
     s = spond.Spond(username=username, password=password)
-    events = await s.get_events(args.f, args.t)
+    events = await s.get_events(min_start=args.f, max_start=args.t)
 
     if not os.path.exists("./exports"):
         os.makedirs("./exports")


### PR DESCRIPTION
This PR updates the `get_events()` call to use keyword params