### PR TITLE
Fix: Spond.update_events(uid...) will modify or overwrite another event, if no event matching uid exists bug

### DIFF
--- a/spond/spond.py
+++ b/spond/spond.py
@@ -350,12 +350,7 @@ class Spond(_SpondBase):
         json results of post command
 
         """
-        if not self.events:
-            await self.get_events()
-        for event in self.events:
-            if event["id"] == uid:
-                break
-
+        event = await self._get_entity(self._EVENT, uid)
         url = f"{self.api_url}sponds/{uid}"
 
         base_event: JSONDict = {


### PR DESCRIPTION
This PR refactors the relevant code to use `self._get_entity(self._EVENT, uid)` to  ensure an error is raised when the uid is not matched, and prevent any event modification.