### PR TITLE
Mark members as non-public and move public AuthenticationError

### DIFF
--- a/spond/__init__.py
+++ b/spond/__init__.py
@@ -9,3 +9,9 @@ else:
 
 JSONDict: TypeAlias = Dict[str, Any]
 """Simple alias for type hinting `dict`s that can be passed to/from JSON-handling functions."""
+
+
+class AuthenticationError(Exception):
+    """Error raised on Spond authentication failure."""
+
+    pass

--- a/spond/base.py
+++ b/spond/base.py
@@ -3,9 +3,7 @@ from typing import Callable
 
 import aiohttp
 
-
-class AuthenticationError(Exception):
-    pass
+from spond import AuthenticationError
 
 
 class _SpondBase(ABC):


### PR DESCRIPTION
As per issue #162, this PR marks these members as non-public, as they are not for end-user use:
```
spond.spond.Spond.chat_url -> spond.spond.Spond._chat_url
spond.spond.Spond.auth -> spond.spond.Spond._auth
spond.spond.Spond.login_chat() -> spond.spond.Spond._login_chat()
```
and moves this, as it should be public, but is currently in a module that only exists to hold the non-public `_SpondBase` class:
```
spond.base.AuthenticationError -> spond.AuthenticationError
```