### PR TITLE
Fix: changed `Spond.get_events()` subgroupId Param to subGroupId

### DIFF
--- a/spond/spond.py
+++ b/spond/spond.py
@@ -300,7 +300,7 @@ class Spond(_SpondBase):
         if group_id:
             params["groupId"] = group_id
         if subgroup_id:
-            params["subgroupId"] = subgroup_id
+            params["subGroupId"] = subgroup_id
 
         async with self.clientsession.get(
             url, headers=self.auth_headers, params=params


### PR DESCRIPTION
After failing to restrict the event search to a specific subgroup, I realized that Spond's API uses subGroupId with a capital 'G' instead of subgroupId.

After reviewing [this issue](https://github.com/Olen/Spond/issues/14), I believe subGroupId is the correct parameter. However, due to certain circumstances, I'm currently unable to test whether my commit resolves the issue.