### PR TITLE
Typing: complete and enforce presence of return type annotations for public functions in main module

### DIFF
--- a/manual_test_functions.py
+++ b/manual_test_functions.py
@@ -7,10 +7,13 @@ Doesn't yet use `get_person(user)` or any `send_`, `update_` methods."""
 
 import asyncio
 import tempfile
+from typing import TYPE_CHECKING
 
 from config import club_id, password, username
+from spond import club, spond
 
-from spond import JSONDict, club, spond
+if TYPE_CHECKING:
+    from spond import JSONDict
 
 DUMMY_ID = "DUMMY_ID"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ target-version = "py39"  # Ruff doesn't yet infer this from [tool.poetry.depende
 
 [tool.ruff.lint]
 select = [
+    "ANN201",  # Missing return type annotation for public function
     "E",  # pycodestyle
     "F",  # Pyflakes
     "I",  # isort
@@ -36,13 +37,18 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# Don't try to sort imports in example files, as non-existent `config` module causes
-# issues in CI
-"attendance.py" = ["I001"]
-"groups.py" = ["I001"]
-"ical.py" = ["I001"]
+# In example files:
+# - Don't try to sort imports as non-existent `config` module causes issues in CI
+# - Don't enforce type annotations for now
+"attendance.py" = ["ANN", "I001"]
+"groups.py" = ["ANN", "I001"]
+"ical.py" = ["ANN", "I001"]
 "manual_test_functions.py" = ["I001"]
-"transactions.py" = ["I001"]
+"transactions.py" = ["ANN", "I001"]
+
+# In tests:
+# - Don't enforce type annotations for now
+"**/{tests}/*" = ["ANN"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ select = [
     "F",  # Pyflakes
     "I",  # isort
     "SIM",  # flake8-simplify
+    "UP",  # pyupgrade
 ]
 ignore = [
     "E501",  # Line too long: needs code refactors first

--- a/spond/__init__.py
+++ b/spond/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict
+from typing import Any
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
@@ -7,7 +7,7 @@ else:
     from typing import TypeAlias
 
 
-JSONDict: TypeAlias = Dict[str, Any]
+JSONDict: TypeAlias = dict[str, Any]
 """Simple alias for type hinting `dict`s that can be passed to/from JSON-handling functions."""
 
 

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
+from . import JSONDict
 from ._event_template import _EVENT_TEMPLATE
 from .base import _SpondBase
 
 if TYPE_CHECKING:
     from datetime import datetime
-
-    from . import JSONDict
 
 
 class Spond(_SpondBase):
@@ -180,7 +179,7 @@ class Spond(_SpondBase):
         user: str | None = None,
         group_uid: str | None = None,
         chat_id: str | None = None,
-    ):
+    ) -> JSONDict:
         """
         Start a new chat or continue an existing one.
 
@@ -348,7 +347,7 @@ class Spond(_SpondBase):
         return await self._get_entity(self._EVENT, uid)
 
     @_SpondBase.require_authentication
-    async def update_event(self, uid: str, updates: JSONDict):
+    async def update_event(self, uid: str, updates: JSONDict) -> JSONDict | None:
         """
         Updates an existing event.
 

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -31,12 +31,12 @@ _SpondBase.require_authentication = mock_require_authentication(Spond.get_event)
 
 
 @pytest.fixture
-def mock_token():
+def mock_token() -> str:
     return MOCK_TOKEN
 
 
 @pytest.fixture
-def mock_payload():
+def mock_payload() -> JSONDict:
     return MOCK_PAYLOAD
 
 
@@ -56,7 +56,9 @@ class TestEventMethods:
         ]
 
     @pytest.mark.asyncio
-    async def test_get_event__happy_path(self, mock_events: list[JSONDict], mock_token):
+    async def test_get_event__happy_path(
+        self, mock_events: list[JSONDict], mock_token
+    ) -> None:
         """Test that a valid `id` returns the matching event."""
 
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
@@ -72,7 +74,7 @@ class TestEventMethods:
     @pytest.mark.asyncio
     async def test_get_event__no_match_raises_exception(
         self, mock_events: list[JSONDict], mock_token
-    ):
+    ) -> None:
         """Test that a non-matched `id` raises KeyError."""
 
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
@@ -85,7 +87,7 @@ class TestEventMethods:
     @pytest.mark.asyncio
     async def test_get_event__blank_id_match_raises_exception(
         self, mock_events: list[JSONDict], mock_token
-    ):
+    ) -> None:
         """Test that a blank `id` raises KeyError."""
 
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
@@ -97,7 +99,7 @@ class TestEventMethods:
 
     @pytest.mark.asyncio
     @patch("aiohttp.ClientSession.put")
-    async def test_change_response(self, mock_put, mock_payload, mock_token):
+    async def test_change_response(self, mock_put, mock_payload, mock_token) -> None:
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
         s.token = mock_token
 
@@ -144,7 +146,9 @@ class TestGroupMethods:
         ]
 
     @pytest.mark.asyncio
-    async def test_get_group__happy_path(self, mock_groups: list[JSONDict], mock_token):
+    async def test_get_group__happy_path(
+        self, mock_groups: list[JSONDict], mock_token
+    ) -> None:
         """Test that a valid `id` returns the matching group."""
 
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
@@ -160,7 +164,7 @@ class TestGroupMethods:
     @pytest.mark.asyncio
     async def test_get_group__no_match_raises_exception(
         self, mock_groups: list[JSONDict], mock_token
-    ):
+    ) -> None:
         """Test that a non-matched `id` raises KeyError."""
 
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
@@ -173,7 +177,7 @@ class TestGroupMethods:
     @pytest.mark.asyncio
     async def test_get_group__blank_id_raises_exception(
         self, mock_groups: list[JSONDict], mock_token
-    ):
+    ) -> None:
         """Test that a blank `id` raises KeyError."""
 
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
@@ -187,7 +191,7 @@ class TestGroupMethods:
 class TestExportMethod:
     @pytest.mark.asyncio
     @patch("aiohttp.ClientSession.get")
-    async def test_get_export(self, mock_get, mock_token):
+    async def test_get_export(self, mock_get, mock_token) -> None:
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
         s.token = mock_token
 


### PR DESCRIPTION
Building on https://github.com/Olen/Spond/pull/152, this PR:

- Completes return hints for public functions, methods in the main module and enforces their presence, i.e. new code in the main module must have return types to pass CI. Some of these go along with what docstrings say is returned, not what may actually be returned. But sorting that is one for a different PR.

- Adds additional return types in tests, but this is still incomplete and not enforced.

It should have zero runtime effect.

Note no actual type checking is enforced yet. 