### PR TITLE
feat: upgrade `pyproject.toml` to Poetry 2.x / fix #174

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,19 @@
-[tool.poetry]
+[project]
 name = "spond"
 version = "1.1.1"
 description = "Simple, unofficial library with some example scripts to access data from the Spond API."
-authors = ["Ola Thoresen <ola@nytt.no>"]
-license = "GPL 3.0"
-readme = 'README.md'
-repository = 'https://github.com/Olen/Spond'
+license = "GPL-3.0-only"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [
+    { name = "Ola Thoresen", email = "ola@nytt.no" },
+]
+dependencies = [
+    "aiohttp>=3.8.5"
+]
 
-[tool.poetry.dependencies]
-python = "^3.9"
-aiohttp = "^3.8.5"
+[project.urls]
+repository = "https://github.com/Olen/Spond"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"
@@ -19,9 +23,6 @@ pytest-asyncio = ">=0.23.6,<0.26.0"
 # Group for dev dependencies which don't require explicit installation in CI,
 # as they are handled by GitHub actions.
 ruff = "^0.9.6"
-
-[tool.ruff]
-target-version = "py39"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
This PR upgrades `pyproject.toml` for Poetry 2.x which allows PEP621-compliant metadata. This should fix #174.

It also: 
- removes the upper bound on Python requirement: from ^3.9 (equivalent to >=3.9, <4) to >=3.9.
  I think ^3.x was the Poetry default/suggested approach, but I feel it had no benefit (we don't know if Python 4 will exist, let alone in what ways it'll be incompatible with this package) , and had the side effect that it required projects with a `Spond` dependency to also set a <4 constraint (at least if also using Poetry)
- removes the upper bound on `aiohttp` requirement from ^3.8.5 (equivalent to >=3.8.5, 4) to >=3.8.5 for similar reasons
- removes the now-redundant explicit Python `target-version` for Ruff.

NB:
- Contributors will need to use Poetry 2.x in future
- Does not affect dev dependencies
- @Olen the licence identifier was the non-standard `GPL 3.0` which is why it shows up on PyPI as 'License: Other/Proprietary License (GPL 3.0)' - I have assumed conservatively that this should be `GPL-3.0-only`. Please advise/amend if it should be `GPL-3.0-or-later`. 







