### PR TITLE
Fix #174: CI ruff step emits warning about version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,20 +30,14 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Install project
-      # Don't install dependencies that are handled within actions
-      run: poetry install --without dev-not-ci
+      run: poetry install
     - name: Lint with ruff
       # By default, exit with error if rule violations, report issues.
-      # Equivalent to `ruff check`. Picks up config from `pyproject.toml`.
-      uses: astral-sh/ruff-action@v3
+      # Picks up config from `pyproject.toml`.
+      run: poetry run ruff check
     - name: Check format with ruff
       # By default, exit with error if the code is not properly formatted.
-      # Equivalent to `ruff format --check --diff`. Picks up config from
-      # `pyproject.toml`.
-      uses: astral-sh/ruff-action@v3
-      with:
-        args: "format --check --diff"
+      # Picks up config from `pyproject.toml`.
+      run: poetry run ruff format --check --diff
     - name: Test with pytest
-      run: |
-        source $VENV
-        pytest
+      run: poetry run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,6 @@ aiohttp = "^3.8.5"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"
 pytest-asyncio = ">=0.23.6,<0.26.0"
-
-[tool.poetry.group.dev-not-ci.dependencies]
-# Group for dev dependencies which don't require explicit installation in CI,
-# as they are handled by GitHub actions.
 ruff = "^0.9.6"
 
 [tool.ruff]


### PR DESCRIPTION
This PR changes the `python-package` GitHub workflow to install and `poetry run ruff...` explicitly, rather than via GitHub action.

This makes things simpler: we now only need a single dev-dependency group instead of two, and CI will now install the `ruff` version specified there.

It also updates the CI `pytest` step to use `poetry run...` to be consistent.