### PR TITLE
fix: 194 JSONDict import incorrectly in type-checking block

### DIFF
--- a/manual_test_functions.py
+++ b/manual_test_functions.py
@@ -7,13 +7,9 @@ Doesn't yet use `get_person(user)` or any `send_`, `update_` methods."""
 
 import asyncio
 import tempfile
-from typing import TYPE_CHECKING
 
 from config import club_id, password, username
-from spond import club, spond
-
-if TYPE_CHECKING:
-    from spond import JSONDict
+from spond import club, spond, JSONDict
 
 DUMMY_ID = "DUMMY_ID"
 


### PR DESCRIPTION
Fixes #194 by moving `import JSONDict` out of a type-checking block.