### PR TITLE
Add update_member and get_members_xlsx methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Get Excel attendance report for a single event, available via the web client.
 ### change_response()
 Change a member's response for an event (e.g. accept/decline)
 
+### update_member()
+Change details about a member. First use get_groups() to get all the member details,
+find the member you what to change and make the changes, then use this method to
+update in Spond.
+
+### get_members_xlsx()
+Get the Excel member export that is downloadable from the Spond web page.
+
 ## Example scripts
 
 The following scripts are included as examples.  Some of the scripts might require additional packages to be installed (csv, ical etc).

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -481,7 +481,7 @@ class Spond(_SpondBase):
         group_id : str
             Group ID of the member
         member : dict
-            Member data to update 
+            Member data to update
 
         Returns
         -------
@@ -498,7 +498,7 @@ class Spond(_SpondBase):
     @_SpondBase.require_authentication
     async def get_members_xlsx(self, group_id: str) -> bytes:
         """Get the Excel member export that is downloadable from the Spond web page.
-                
+
         Parameters
         ----------
         group_id : str

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -467,7 +467,7 @@ class Spond(_SpondBase):
         raise KeyError(errmsg)
 
     @_SpondBase.require_authentication
-    async def update_member(self, group_id: str, member: dict):
+    async def update_member(self, group_id: str, member: dict) -> JSONDict:
         """
         Update member details.
         Subject to authenticated user's access permissions.

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -465,3 +465,50 @@ class Spond(_SpondBase):
                 return entity
         errmsg = f"No {entity_type} with id='{uid}'."
         raise KeyError(errmsg)
+
+    @_SpondBase.require_authentication
+    async def update_member(self, group_id: str, member: dict):
+        """
+        Update member details.
+        Subject to authenticated user's access permissions.
+
+        Use by first getting the member data with either the get_groups()
+        or get_personb(), modify some value and write back with this
+        method.
+
+        Parameters
+        ----------
+        group_id : str
+            Group ID of the member
+        member : dict
+            Member data to update 
+
+        Returns
+        -------
+        dict
+             The response from the Spond server which is the Updated memberi
+             data on success or an error message on failure.
+        """
+
+        url = f"{self.api_url}group/{group_id}/member"
+        data = member
+        r = await self.clientsession.post(url, json=data, headers=self.auth_headers)
+        return await r.json()
+
+    @_SpondBase.require_authentication
+    async def get_members_xlsx(self, group_id: str) -> bytes:
+        """Get the Excel member export that is downloadable from the Spond web page.
+                
+        Parameters
+        ----------
+        group_id : str
+            Group ID of the members
+
+        Returns:
+        -------
+            bytes: XLSX binary data
+        """
+        url = f"{self.api_url}group/{group_id}/exportMembers"
+        async with self.clientsession.get(url, headers=self.auth_headers) as r:
+            output_data = await r.read()
+            return output_data


### PR DESCRIPTION
Added two methods

1. update_member() which will POST updated member data back to Spond
2. get_members_xlsx() which will download the Excel sheet that can be manually downloaded from the Spond website. This can easily then be converted into a Dataframe.