### PR TITLE
CI: add Python 3.14 to matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
This PR adds newly released Python 3.14 to the CI testing/linting matrix, in order to provide assurance that the package works on this version.