### PR TITLE
Simplify dependency ranges; bump dev dependencies to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ readme = 'README.md'
 repository = 'https://github.com/Olen/Spond'
 
 [tool.poetry.dependencies]
-python = "^3.10"
-aiohttp = "^3.8.5"
+python = ">=3.10"
+aiohttp = ">=3.8.5"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.1.1"
-pytest-asyncio = ">=0.23.6,<0.26.0"
-ruff = "^0.9.6"
+pytest = ">=9.0.2"
+pytest-asyncio = ">=1.3.0"
+ruff = ">=0.15.0"
 
 [tool.ruff]
 target-version = "py310"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]


### PR DESCRIPTION
This PR simplifies runtime (python, aiohttp) dependency constraints from 'compatible with' to 'equal or greater than', i.e. removes upper bounds. This has the side benefit that downstream users of the package no longer have to set an upper bound for Python in their dependencies.

It does the same for dev/CI dependencies. 
It also bumps dev/CI dependencies' lower bound to the current latest version, which isn't strictly necessary but simpler than a more detailed approach - the lower bounds were very old versions.