### PR TITLE
Require Python >= 3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Check out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = 'README.md'
 repository = 'https://github.com/Olen/Spond'
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 aiohttp = "^3.8.5"
 
 [tool.poetry.group.dev.dependencies]
@@ -17,7 +17,7 @@ pytest-asyncio = ">=0.23.6,<0.26.0"
 ruff = "^0.9.6"
 
 [tool.ruff]
-target-version = "py39"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
+target-version = "py310"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
 
 [tool.ruff.lint]
 select = [

--- a/spond/__init__.py
+++ b/spond/__init__.py
@@ -1,11 +1,4 @@
-import sys
-from typing import Any
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias
-
+from typing import Any, TypeAlias
 
 JSONDict: TypeAlias = dict[str, Any]
 """Simple alias for type hinting `dict`s that can be passed to/from JSON-handling functions."""

--- a/spond/base.py
+++ b/spond/base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Callable
+from collections.abc import Callable
 
 import aiohttp
 


### PR DESCRIPTION
This PR sets the library and CI jobs to require Python >= 3.10, i.e. drops Python 3.9 which is end-of-life and not supported by latest Poetry, so is failing CI.

It also makes a couple of import simplifications/upgrades which 3.10 allows.