### PR TITLE
CI: add permissions to `python-package.yml` workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Applying principle of least privilege, explicitly sets permissions to `contents: read` rather than using repo/account default.

`release.yml` already has permissions defined.