### PR TITLE
feat: legg til get_posts() for å hente innlegg fra gruppevegger

### DIFF
--- a/spond/spond.py
+++ b/spond/spond.py
@@ -25,6 +25,7 @@ class Spond(_SpondBase):
         self._auth = None
         self.groups: list[JSONDict] | None = None
         self.events: list[JSONDict] | None = None
+        self.posts: list[JSONDict] | None = None
         self.messages: list[JSONDict] | None = None
         self.profile: JSONDict | None = None
 
@@ -132,6 +133,63 @@ class Spond(_SpondBase):
             or person["firstName"] + " " + person["lastName"] == match_str
             or ("profile" in person and person["profile"]["id"] == match_str)
         )
+
+    @_SpondBase.require_authentication
+    async def get_posts(
+        self,
+        group_id: str | None = None,
+        max_posts: int = 20,
+        include_comments: bool = True,
+    ) -> list[JSONDict] | None:
+        """
+        Retrieve posts from group walls.
+
+        Posts are announcements/messages posted to group walls, as opposed to
+        chat messages or events.
+
+        Parameters
+        ----------
+        group_id : str, optional
+            Filter by group. Uses `groupId` API parameter.
+        max_posts : int, optional
+            Set a limit on the number of posts returned.
+            For performance reasons, defaults to 20.
+            Uses `max` API parameter.
+        include_comments : bool, optional
+            Include comments on posts.
+            Defaults to True.
+            Uses `includeComments` API parameter.
+
+        Returns
+        -------
+        list[JSONDict] or None
+            A list of posts, each represented as a dictionary, or None if no
+            posts are available.
+
+        Raises
+        ------
+        ValueError
+            Raised when the request to the API fails.
+        """
+        url = f"{self.api_url}posts"
+        params: dict[str, str] = {
+            "type": "PLAIN",
+            "max": str(max_posts),
+            "includeComments": str(include_comments).lower(),
+        }
+        if group_id:
+            params["groupId"] = group_id
+
+        async with self.clientsession.get(
+            url, headers=self.auth_headers, params=params
+        ) as r:
+            if not r.ok:
+                error_details = await r.text()
+                raise ValueError(
+                    f"Request failed with status {r.status}: {error_details}"
+                )
+            self.posts = await r.json()
+            return self.posts
 
     @_SpondBase.require_authentication
     async def get_messages(self, max_chats: int = 100) -> list[JSONDict] | None:

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -171,7 +171,7 @@ class Spond(_SpondBase):
         ValueError
             Raised when the request to the API fails.
         """
-        url = f"{self.api_url}posts"
+        url = f"{self.api_url}posts/"
         params: dict[str, str] = {
             "type": "PLAIN",
             "max": str(max_posts),

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -303,9 +303,7 @@ class TestPostMethods:
         s.token = mock_token
 
         mock_get.return_value.__aenter__.return_value.ok = True
-        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
-            return_value=[]
-        )
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=[])
 
         await s.get_posts(max_posts=5)
 
@@ -320,9 +318,7 @@ class TestPostMethods:
         s.token = mock_token
 
         mock_get.return_value.__aenter__.return_value.ok = True
-        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
-            return_value=[]
-        )
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=[])
 
         await s.get_posts(include_comments=False)
 

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -212,3 +212,135 @@ class TestExportMethod:
             },
         )
         assert data == mock_binary
+
+
+class TestPostMethods:
+    MOCK_POSTS: list[JSONDict] = [
+        {
+            "id": "POST1",
+            "type": "PLAIN",
+            "groupId": "GID1",
+            "title": "Post One",
+            "body": "Body of post one",
+            "timestamp": "2026-03-03T19:20:00.270Z",
+            "comments": [],
+        },
+        {
+            "id": "POST2",
+            "type": "PLAIN",
+            "groupId": "GID2",
+            "title": "Post Two",
+            "body": "Body of post two",
+            "timestamp": "2026-02-20T19:21:20.447Z",
+            "comments": [{"id": "C1", "text": "A comment"}],
+        },
+    ]
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_posts__happy_path(self, mock_get, mock_token) -> None:
+        """Test that get_posts returns posts from the API."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = True
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value=self.MOCK_POSTS
+        )
+
+        posts = await s.get_posts()
+
+        mock_url = "https://api.spond.com/core/v1/posts"
+        mock_get.assert_called_once_with(
+            mock_url,
+            headers={
+                "content-type": "application/json",
+                "Authorization": f"Bearer {mock_token}",
+            },
+            params={
+                "type": "PLAIN",
+                "max": "20",
+                "includeComments": "true",
+            },
+        )
+        assert posts == self.MOCK_POSTS
+        assert s.posts == self.MOCK_POSTS
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_posts__with_group_id(self, mock_get, mock_token) -> None:
+        """Test that group_id is passed as a query parameter."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = True
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value=[self.MOCK_POSTS[0]]
+        )
+
+        posts = await s.get_posts(group_id="GID1")
+
+        mock_get.assert_called_once_with(
+            "https://api.spond.com/core/v1/posts",
+            headers={
+                "content-type": "application/json",
+                "Authorization": f"Bearer {mock_token}",
+            },
+            params={
+                "type": "PLAIN",
+                "max": "20",
+                "includeComments": "true",
+                "groupId": "GID1",
+            },
+        )
+        assert len(posts) == 1
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_posts__custom_max(self, mock_get, mock_token) -> None:
+        """Test that max_posts parameter is respected."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = True
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value=[]
+        )
+
+        await s.get_posts(max_posts=5)
+
+        call_params = mock_get.call_args[1]["params"]
+        assert call_params["max"] == "5"
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_posts__no_comments(self, mock_get, mock_token) -> None:
+        """Test that include_comments=False is passed correctly."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = True
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value=[]
+        )
+
+        await s.get_posts(include_comments=False)
+
+        call_params = mock_get.call_args[1]["params"]
+        assert call_params["includeComments"] == "false"
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_posts__api_error_raises(self, mock_get, mock_token) -> None:
+        """Test that a failed API response raises ValueError."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = False
+        mock_get.return_value.__aenter__.return_value.status = 401
+        mock_get.return_value.__aenter__.return_value.text = AsyncMock(
+            return_value="Unauthorized"
+        )
+
+        with pytest.raises(ValueError, match="401"):
+            await s.get_posts()

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -250,7 +250,7 @@ class TestPostMethods:
 
         posts = await s.get_posts()
 
-        mock_url = "https://api.spond.com/core/v1/posts"
+        mock_url = "https://api.spond.com/core/v1/posts/"
         mock_get.assert_called_once_with(
             mock_url,
             headers={
@@ -281,7 +281,7 @@ class TestPostMethods:
         posts = await s.get_posts(group_id="GID1")
 
         mock_get.assert_called_once_with(
-            "https://api.spond.com/core/v1/posts",
+            "https://api.spond.com/core/v1/posts/",
             headers={
                 "content-type": "application/json",
                 "Authorization": f"Bearer {mock_token}",


### PR DESCRIPTION
## Beskrivelse

Legger til en ny `get_posts()`-metode i `Spond`-klassen for å hente innlegg (posts) fra gruppevegger via API-endepunktet `/core/v1/posts`.

Innlegg er kunngjøringer/meldinger som publiseres på gruppevegger, og er forskjellig fra chatmeldinger (`get_messages`) og hendelser (`get_events`).

## Parametere

| Parameter | Type | Standard | Beskrivelse |
|---|---|---|---|
| `group_id` | `str \| None` | `None` | Filtrer etter gruppe |
| `max_posts` | `int` | `20` | Maks antall innlegg som returneres |
| `include_comments` | `bool` | `True` | Inkluder kommentarer på innlegg |

## Eksempel

```python
s = Spond(username="user", password="pass")
posts = await s.get_posts(group_id="ABC123", max_posts=10)
for post in posts:
    print(post["title"], post["body"])
```

## Tester

5 nye tester er lagt til i `tests/test_spond.py`:
- Henting av innlegg (happy path)
- Filtrering etter `group_id`
- Egendefinert `max_posts`
- `include_comments=False`
- Feilhåndtering ved API-feil

Alle eksisterende og nye tester bestått.

Closes #67