### PR TITLE
refactor: upgrade `examples/` to use Pathlib

### DIFF
--- a/examples/attendance.py
+++ b/examples/attendance.py
@@ -1,13 +1,15 @@
 import argparse
 import asyncio
 import csv
-import os
 import re
 from datetime import date
+from pathlib import Path
 
 from config import password, username
 
 from spond import spond
+
+EXPORT_DIRPATH = Path("./exports")
 
 parser = argparse.ArgumentParser(
     description="Creates an attendance.csv for organizers of events."
@@ -32,17 +34,15 @@ parser.add_argument(
 args = parser.parse_args()
 
 
-async def main():
+async def main() -> None:
     session = spond.Spond(username=username, password=password)
     events = await session.get_events(min_start=args.f, max_start=args.t)
-
-    if not os.path.exists("./exports"):
-        os.makedirs("./exports")
+    EXPORT_DIRPATH.mkdir(exist_ok=True)
 
     for e in events:
         base_filename = _sanitise_filename(f"{e['startTimestamp']}-{e['heading']}")
-        filename = os.path.join("./exports", base_filename + ".csv")
-        with open(filename, "w", newline="") as csvfile:
+        filepath = EXPORT_DIRPATH / f"{base_filename}.csv"
+        with filepath.open("w", newline="") as csvfile:
             spamwriter = csv.writer(
                 csvfile, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
             )

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -1,29 +1,29 @@
 import asyncio
 import json
-import os
+from pathlib import Path
 
 from config import password, username
 
 from spond import spond
 
-if not os.path.exists("./exports"):
-    os.makedirs("./exports")
+EXPORT_DIRPATH = Path("./exports")
 
 
-async def main():
+async def main() -> None:
     s = spond.Spond(username=username, password=password)
     groups = await s.get_groups()
+    EXPORT_DIRPATH.mkdir(exist_ok=True)
+
     for group in groups:
         name = group["name"]
         data = json.dumps(group, indent=4, sort_keys=True)
         keepcharacters = (" ", ".", "_")
-        filename = os.path.join(
-            "./exports",
-            "".join(c for c in name if c.isalnum() or c in keepcharacters).rstrip()
-            + ".json",
-        )
-        print(filename)
-        with open(filename, "w") as out_file:
+        base_filename = "".join(
+            c for c in name if c.isalnum() or c in keepcharacters
+        ).rstrip()
+        json_filepath = EXPORT_DIRPATH / f"{base_filename}.json"
+        print(json_filepath)
+        with json_filepath.open("w") as out_file:
             out_file.write(data)
 
     await s.clientsession.close()

--- a/examples/ical.py
+++ b/examples/ical.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python3
 
 import asyncio
-import os
+from pathlib import Path
 
 from config import password, username
 from ics import Calendar, Event
 
 from spond import spond
 
-if not os.path.exists("./exports"):
-    os.makedirs("./exports")
-
-ics_file = os.path.join("./exports", "spond.ics")
+EXPORT_DIRPATH = Path("./exports")
 
 
-async def main():
+async def main() -> None:
     s = spond.Spond(username=username, password=password)
     c = Calendar()
     c.method = "PUBLISH"
     events = await s.get_events()
+    EXPORT_DIRPATH.mkdir(exist_ok=True)
+    ics_filepath = EXPORT_DIRPATH / "spond.ics"
+
     for event in events:
         e = Event()
         e.uid = event["id"]
@@ -32,8 +32,10 @@ async def main():
         if "location" in event:
             e.location = f"{event['location'].get('feature')}, {event['location'].get('address')}"
         c.events.add(e)
-    with open(ics_file, "w") as out_file:
+
+    with ics_filepath.open("w") as out_file:
         out_file.writelines(c)
+
     await s.clientsession.close()
 
 

--- a/examples/transactions.py
+++ b/examples/transactions.py
@@ -7,6 +7,8 @@ from config import club_id, password, username
 
 from spond.club import SpondClub
 
+EXPORT_DIRPATH = Path("./exports")
+
 parser = argparse.ArgumentParser(
     description="Creates an transactions.csv to keep track of payments accessible on Spond Club"
 )
@@ -22,9 +24,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 
-async def main():
-    output_path = Path("./exports/transactions.csv")
-
+async def main() -> None:
     s = SpondClub(username=username, password=password)
     transactions = await s.get_transactions(club_id=club_id, max_items=args.max)
     if not transactions:
@@ -32,15 +32,17 @@ async def main():
         await s.clientsession.close()
         return
 
+    EXPORT_DIRPATH.mkdir(exist_ok=True)
+    csv_filepath = EXPORT_DIRPATH / "transactions.csv"
     header = transactions[0].keys()
 
-    with open(output_path, "w", newline="") as file:
+    with csv_filepath.open("w", newline="") as file:
         writer = csv.DictWriter(file, fieldnames=header)
         writer.writeheader()
         for t in transactions:
             writer.writerow(t)
 
-    print(f"Collected {len(transactions)} transactions. Written to {output_path}")
+    print(f"Collected {len(transactions)} transactions. Written to {csv_filepath}")
     await s.clientsession.close()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # In example files:
 # - Don't try to sort imports as non-existent `config` module causes issues in CI
-# - Don't enforce type annotations for now
-"examples/attendance.py" = ["ANN", "I001"]
-"examples/groups.py" = ["ANN", "I001"]
-"examples/ical.py" = ["ANN", "I001"]
-"examples/manual_test_functions.py" = ["I001"]
-"examples/transactions.py" = ["ANN", "I001"]
+"examples/*" = ["I001"]
 
 # In tests:
 # - Don't enforce type annotations for now


### PR DESCRIPTION
This PR upgrades examples to use the `Pathlib` library and f-strings, and makes path handling code more consistent.

It also brings type hints for these files up to the same level as the main package.

NB: In order to keep each script self-contained, it does _not_ refactor the repeated path-handling code to a shared module.