### PR TITLE
typing: fix `Spond.update_event()` return hint

### DIFF
--- a/spond/spond.py
+++ b/spond/spond.py
@@ -422,7 +422,7 @@ class Spond(_SpondBase):
         return await self._get_entity(self._EVENT, uid)
 
     @_SpondBase.require_authentication
-    async def update_event(self, uid: str, updates: JSONDict) -> JSONDict | None:
+    async def update_event(self, uid: str, updates: JSONDict) -> list[JSONDict] | None:
         """
         Updates an existing event.
 


### PR DESCRIPTION
The PR corrects the `Spond.update_event() return annotation from `JSONDict | None` to `list[JSONDict] | None`.

The issue and fix should have no runtime impact.