### PR TITLE
feat(ical): use meetupTimestamp as event start when available

### DIFF
--- a/examples/ical.py
+++ b/examples/ical.py
@@ -23,6 +23,11 @@ async def main() -> None:
         e = Event()
         e.uid = event["id"]
         e.name = event["heading"]
+        # Match events expose two start times: `startTimestamp` is the
+        # kickoff, while `meetupTimestamp` is when participants are expected
+        # to arrive (Norwegian: "oppmøtetid"). Training events only have
+        # `startTimestamp`. We prefer the meet-up time so calendar
+        # subscribers see when to show up, and fall back to kickoff.
         e.begin = event.get("meetupTimestamp", event["startTimestamp"])
         e.end = event["endTimestamp"]
         e.sequence = event["updated"]

--- a/examples/ical.py
+++ b/examples/ical.py
@@ -23,7 +23,7 @@ async def main() -> None:
         e = Event()
         e.uid = event["id"]
         e.name = event["heading"]
-        e.begin = event["startTimestamp"]
+        e.begin = event.get("meetupTimestamp", event["startTimestamp"])
         e.end = event["endTimestamp"]
         e.sequence = event["updated"]
         e.description = event.get("description")


### PR DESCRIPTION
## Summary
- Match events return both `startTimestamp` (kickoff) and `meetupTimestamp` ("oppmøtetid" — when participants should arrive). Today the ICS example only surfaces kickoff, so subscribers see no hint of the earlier meet-up.
- Use `meetupTimestamp` as the ICS event begin when present, falling back to `startTimestamp` for events without a meet-up (e.g. training events).
- Added an inline comment in the example explaining the two timestamps.

## Test plan
- [ ] Run `examples/ical.py` against a group with both training and match events; confirm match `VEVENT` `DTSTART` matches the meet-up time and training events are unchanged.