### PR TITLE
fix: update login to /auth2/login endpoint

### DIFF
--- a/spond/base.py
+++ b/spond/base.py
@@ -35,11 +35,17 @@ class _SpondBase(ABC):
         return wrapper
 
     async def login(self) -> None:
-        login_url = f"{self.api_url}login"
+        login_url = f"{self.api_url}auth2/login"
         data = {"email": self.username, "password": self.password}
         async with self.clientsession.post(login_url, json=data) as r:
             login_result = await r.json()
-            self.token = login_result.get("loginToken")
-            if self.token is None:
-                err_msg = f"Login failed. Response received: {login_result}"
-                raise AuthenticationError(err_msg)
+        self.token = self._extract_access_token(login_result)
+
+    @staticmethod
+    def _extract_access_token(login_result: dict) -> str:
+        access = login_result.get("accessToken")
+        if isinstance(access, dict):
+            token = access.get("token")
+            if isinstance(token, str) and token:
+                return token
+        raise AuthenticationError(f"Login failed. Response received: {login_result}")

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from spond import AuthenticationError
 from spond.base import _SpondBase
 from spond.spond import Spond
 
@@ -340,3 +341,61 @@ class TestPostMethods:
 
         with pytest.raises(ValueError, match="401"):
             await s.get_posts()
+
+
+class TestLogin:
+    @pytest.mark.parametrize(
+        ("login_result", "expected"),
+        [
+            ({"accessToken": {"token": "ABC", "expiration": "2026-05-14T12:00:00Z"}}, "ABC"),
+        ],
+    )
+    def test_extract_access_token__happy_path(self, login_result, expected) -> None:
+        assert _SpondBase._extract_access_token(login_result) == expected
+
+    @pytest.mark.parametrize(
+        "login_result",
+        [
+            {"error": "Invalid credentials"},
+            {"accessToken": None},
+            {"accessToken": {}},
+            {"accessToken": {"token": ""}},
+            {"accessToken": {"token": None}},
+        ],
+    )
+    def test_extract_access_token__bad_shape_raises(self, login_result) -> None:
+        with pytest.raises(AuthenticationError):
+            _SpondBase._extract_access_token(login_result)
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.post")
+    async def test_login__happy_path(self, mock_post) -> None:
+        mock_response = {
+            "accessToken": {"token": "ABC", "expiration": "2026-05-14T12:00:00Z"},
+            "refreshToken": {"token": "REF", "expiration": "2026-08-11T12:00:00Z"},
+            "passwordToken": {"token": "PWD", "expiration": "2026-05-13T13:00:00Z"},
+        }
+        mock_post.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value=mock_response
+        )
+
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        await s.login()
+
+        mock_post.assert_called_once_with(
+            "https://api.spond.com/core/v1/auth2/login",
+            json={"email": MOCK_USERNAME, "password": MOCK_PASSWORD},
+        )
+        assert s.token == "ABC"
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.post")
+    async def test_login__error_response_raises(self, mock_post) -> None:
+        mock_post.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value={"error": "Invalid credentials"}
+        )
+
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        with pytest.raises(AuthenticationError):
+            await s.login()
+        assert s.token is None

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -347,7 +347,10 @@ class TestLogin:
     @pytest.mark.parametrize(
         ("login_result", "expected"),
         [
-            ({"accessToken": {"token": "ABC", "expiration": "2026-05-14T12:00:00Z"}}, "ABC"),
+            (
+                {"accessToken": {"token": "ABC", "expiration": "2026-05-14T12:00:00Z"}},
+                "ABC",
+            ),
         ],
     )
     def test_extract_access_token__happy_path(self, login_result, expected) -> None:


### PR DESCRIPTION
## Summary
- Spond replaced `https://api.spond.com/core/v1/login` with `https://api.spond.com/core/v1/auth2/login` on 2026-05-13, breaking all calls (issue #229).
- The new response wraps the bearer token under `accessToken.token` (with an ISO expiration) instead of a flat `loginToken` string.
- Token extraction factored into a static helper so a future refresh-token path can reuse the parser without restructuring `login()`. Public API (`self.token`, `auth_headers`, `login()` signature) is unchanged.

## Test plan
- [x] New `TestLogin` class adds the first test coverage for `login()` — happy path + error-response path + parametrized unit tests on the parser
- [x] `pytest` — 21 passed (8 new)
- [x] `ruff check` — clean
- [ ] Manual smoke test: run an example against a real account (reviewer to confirm)

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)