### PR TITLE
ci: opt-in auto-update of PRs labeled 'updateme'

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -21,10 +21,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -u
+          set -euo pipefail
           gh pr list --repo "$GITHUB_REPOSITORY" --state open --label updateme \
-              --json number,isCrossRepository \
-              --jq '.[] | "\(.number) \(.isCrossRepository)"' \
+              --json number,isCrossRepository,baseRefName \
+              --jq '.[] | select(.baseRefName == "main") | "\(.number) \(.isCrossRepository)"' \
           | while read -r num is_fork; do
               if [ "$is_fork" = "true" ]; then
                   echo "Skip PR #$num (fork — cannot push via GITHUB_TOKEN)"

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -22,7 +22,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh pr list --repo "$GITHUB_REPOSITORY" --state open --label updateme \
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open --label updateme --limit 200 \
               --json number,isCrossRepository,baseRefName \
               --jq '.[] | select(.baseRefName == "main") | "\(.number) \(.isCrossRepository)"' \
           | while read -r num is_fork; do
@@ -32,5 +32,5 @@ jobs:
               fi
               echo "Updating PR #$num"
               gh pr update-branch "$num" --repo "$GITHUB_REPOSITORY" \
-                  || echo "  -> PR #$num could not be updated (likely conflicting)"
+                  || echo "  -> PR #$num: update-branch failed (see preceding gh output; possible causes: merge conflict, branch protection, transient API error)"
           done

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,0 +1,36 @@
+name: Auto-update PRs
+
+on:
+  push:
+    branches: [main]
+
+# Serialize so two close-together merges don't race the update API.
+concurrency:
+  group: auto-update-prs
+  cancel-in-progress: false
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PRs labeled 'updateme' to latest main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -u
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open --label updateme \
+              --json number,isCrossRepository \
+              --jq '.[] | "\(.number) \(.isCrossRepository)"' \
+          | while read -r num is_fork; do
+              if [ "$is_fork" = "true" ]; then
+                  echo "Skip PR #$num (fork — cannot push via GITHUB_TOKEN)"
+                  continue
+              fi
+              echo "Updating PR #$num"
+              gh pr update-branch "$num" --repo "$GITHUB_REPOSITORY" \
+                  || echo "  -> PR #$num could not be updated (likely conflicting)"
+          done

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ Add the `updateme` label to a PR targeting `main` and a GitHub Actions workflow 
 Limitations:
 - Only acts on PRs whose base branch is `main`. PRs targeting other branches are ignored even with the label.
 - Only works for PRs from branches in this repository. PRs from forks cannot be pushed to via the workflow's token and will be skipped (the workflow logs which PRs it skipped).
-- If the update would cause a merge conflict, that PR is skipped for this run and logged. The label stays on, so the next push to `main` will retry automatically once the conflict is resolved.
+- If `gh pr update-branch` fails for a given PR (merge conflict, branch protection rule, transient API error, etc.), that PR is skipped for this run and the failure is logged. The label stays on, so the next push to `main` will retry automatically.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Demonstrates most `get...()` methods.
 
 ### Keeping a PR up to date with `main`
 
-Add the `updateme` label to a PR and a GitHub Actions workflow will automatically merge `main` into the PR branch every time `main` advances. This is opt-in: PRs without the label are left alone.
+Add the `updateme` label to a PR targeting `main` and a GitHub Actions workflow will automatically merge `main` into the PR branch every time `main` advances. This is opt-in: PRs without the label are left alone.
 
 Limitations:
+- Only acts on PRs whose base branch is `main`. PRs targeting other branches are ignored even with the label.
 - Only works for PRs from branches in this repository. PRs from forks cannot be pushed to via the workflow's token and will be skipped (the workflow logs which PRs it skipped).
-- If the update would cause a merge conflict, the PR is left as-is. Resolve the conflict by hand and re-apply the label if you want auto-update to resume.
+- If the update would cause a merge conflict, that PR is skipped for this run and logged. The label stays on, so the next push to `main` will retry automatically once the conflict is resolved.

--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ Demonstrates most `get...()` methods.
 [Asyncio](https://docs.python.org/3/library/asyncio.html) might seem intimidating in the beginning, but for basic stuff, it is quite easy to follow the examples above, and just remeber to prefix functions that use the API with `async def ...` and to `await` all API-calls and all calls to said functions.
 
 [This article](https://realpython.com/async-io-python/) will give a nice introduction to both why, when and how to use asyncio in projects.
+
+## Contributing
+
+### Keeping a PR up to date with `main`
+
+Add the `updateme` label to a PR and a GitHub Actions workflow will automatically merge `main` into the PR branch every time `main` advances. This is opt-in: PRs without the label are left alone.
+
+Limitations:
+- Only works for PRs from branches in this repository. PRs from forks cannot be pushed to via the workflow's token and will be skipped (the workflow logs which PRs it skipped).
+- If the update would cause a merge conflict, the PR is left as-is. Resolve the conflict by hand and re-apply the label if you want auto-update to resume.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/auto-update-prs.yml`: on every push to `main`, iterate open PRs labeled `updateme` and call `gh pr update-branch` to merge new `main` into each PR branch.
- Opt-in via label so it doesn't churn CI for every open PR — only those the maintainer flags participate.
- Fork PRs are skipped (`GITHUB_TOKEN` cannot push to a fork) with a clear log line; conflicting PRs are logged and skipped.
- `concurrency:` group serializes runs so back-to-back merges to `main` don't race the API.
- README gets a short Contributing section documenting the label and its limitations.

## Setup after merge
Create the `updateme` label once:

```bash
gh label create updateme --description "Auto-update from main on every merge" --color "0e8a16"
```

Then add it to any PR you want kept current: `gh pr edit <num> --add-label updateme` (or via the web UI).

## Test plan
- [x] `ruff check` — clean
- [x] `pytest` — passes (13 tests, unchanged)
- [ ] After merge: apply the `updateme` label to a non-fork PR (e.g. dependabot's #226), then push a trivial commit to `main` and confirm the workflow updates #226's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)