### PR TITLE
Releasing 1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spond"
-version = "1.2.0"
+version = "1.2.1"
 description = "Simple, unofficial library with some example scripts to access data from the Spond API."
 authors = ["Ola Thoresen <ola@nytt.no>"]
 license = "GPL 3.0"


### PR DESCRIPTION
## Summary

Patch release. Bumps `pyproject.toml` from `1.2.0` to `1.2.1`.

Merging this PR triggers `.github/workflows/release.yml`, which will:
1. Tag `v1.2.1` on `main`
2. Auto-generate release notes from PRs merged since `v1.2.0`
3. Publish to PyPI via OIDC

## Headline change in this release

- **fix: login restored against the new `/auth2/login` endpoint** (#229, #230) — Spond replaced the `/core/v1/login` endpoint on 2026-05-13 and the library was returning 404 on every authenticated call. This is the only library-facing change in 1.2.1.

## Also included since 1.2.0

- ci: opt-in auto-update of PRs labeled `updateme` (#231)
- ci(deps): bump `softprops/action-gh-release` v2 → v3 (#226)
- feat(ical example): use `meetupTimestamp` as event start when available (#228) — example-script only, no library change

## Still open at release time (intentional)

- #204, #211 — dependabot CI-action bumps; ride into the next release.
- #197 — needs rebase + docstring cleanup.
- #169 — owner question still open.

## Test plan
- [x] `pytest` — 21 passed (`main` includes the new `TestLogin` class added in #230)
- [x] `ruff check` — clean
- [ ] After merge: confirm release workflow produced `v1.2.1` tag, GitHub Release, and PyPI artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)