### PR TITLE
ci: use GitHub native release notes generator (fixes #225)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,6 @@ jobs:
             exit 1
           fi
 
-      - name: "🗝️ Get previous release version"
-        id: last_release
-        uses: InsonusK/get-latest-release@v1.1.0
-        with:
-          myToken: ${{ github.token }}
-          exclude_types: "draft|prerelease"
-
       - name: "🏷️ Create new tag"
         uses: rickstaa/action-create-tag@v1
         id: "tag_create"
@@ -68,21 +61,12 @@ jobs:
           tag_exists_error: false
           message: "✅ Tag Version v${{ env.VERSION }} created"
 
-      - name: "🗒️ Generate release changelog"
-        id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }} 
-          sinceTag: ${{ steps.last_release.outputs.tag_name }}
-          headerLabel: "# Notable changes since ${{ steps.last_release.outputs.tag_name }}"
-          stripGeneratorNotice: true
-
       - name: 🚀 Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}
           name: 🎉 Release v${{ env.VERSION }}
-          body: "${{ steps.changelog.outputs.changelog }}"
+          generate_release_notes: true
           draft: false
           prerelease: false
 


### PR DESCRIPTION
## Summary

- Replace abandoned `heinrichreimer/github-changelog-generator-action@v2.4` (last release 2022) with `softprops/action-gh-release`'s built-in `generate_release_notes: true`, which calls GitHub's `/releases/generate-notes` API server-side.
- Also drops the now-unused `InsonusK/get-latest-release@v1.1.0` step (another abandoned action; only existed to feed `sinceTag` to the changelog generator).
- Fixes #225: the `%0A` line-break encoding in v1.2.0 and v1.2.1 release bodies. Root cause is that the changelog action still used the deprecated `::set-output::` URL-encoded format; GitHub Actions stopped auto-decoding `%0A` to newlines, so the encoded form leaked into the `body:` string. Switching to `generate_release_notes` bypasses `${{ }}` interpolation of the changelog text entirely, which structurally eliminates that class of bug.

## Test plan

- [ ] Local `pytest` passes (21 tests)
- [ ] Local `ruff check` clean
- [ ] Local `ruff format --check` clean (with ruff 0.15.12 matching `>=0.15.0` pin)
- [ ] CI: Python package matrix all green
- [ ] Verified at next release: notes render with real newlines instead of `%0A`

Optional follow-up: add `.github/release.yml` to group PRs by label (Features / Bug Fixes / Other) — left out of this PR to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)