### PR TITLE
fix: pin pytest-asyncio default fixture loop scope (#189)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ pytest = ">=9.0.2"
 pytest-asyncio = ">=1.3.0"
 ruff = ">=0.15.0"
 
+[tool.pytest.ini_options]
+# Pinned explicitly: pytest-asyncio's default is currently unset and will
+# flip to "function" in a future release — set now so behaviour can't drift.
+asyncio_default_fixture_loop_scope = "function"
+
 [tool.ruff]
 target-version = "py310"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
 


### PR DESCRIPTION
## Summary

- Set `asyncio_default_fixture_loop_scope = "function"` in a new `[tool.pytest.ini_options]` block.
- Addresses #189 by pinning the future default explicitly, which is the recommendation in the issue's last paragraph.

## Context

The literal deprecation warning text in #189 no longer fires in `pytest-asyncio` 1.3.0 (verified locally with `pytest -W error::DeprecationWarning` — silent). But the underlying behaviour-drift risk is still real: `asyncio_default_fixture_loop_scope` was unset, and pytest-asyncio's CHANGELOG warns it will default to `"function"` in a future release. Setting it now means our test setup is immune to that flip whenever it lands.

Verified locally — `pytest` header now reads:

```
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, ...
```

(was `=None` before this change).

## ⚠️ Release workflow side-effect on merge

Because this PR touches `pyproject.toml`, merging will trigger `.github/workflows/release.yml` (which has `paths: pyproject.toml`). The tag-exists guard (workflow line 48-54) catches it — version is still `1.2.1`, tag `v1.2.1` exists, the step exits 1 — so **no release will be cut**, but the workflow run will show as red on the merge commit. Wanted to flag this rather than have it surprise you.

(Long-term fix: scope `paths:` to only fire when the version actually changes, e.g. via a `if: contains(github.event.head_commit.modified, 'pyproject.toml') && ...` check or by gating on a release PR label. Out of scope for this PR.)

## Test plan

- [x] Local `pytest` — 21 tests pass
- [x] Local `ruff check` — clean
- [x] Local `ruff format --check` — clean
- [ ] CI: full Python matrix green

## Not addressed in this PR

Issue #189 also suggests adopting `pytest-github-actions-annotate-failures` so warnings surface in the Actions UI. That's a separate, additive change — left for a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)