### PR TITLE
fix: raise KeyError instead of TypeError on empty results (#136)

### DIFF
--- a/spond/spond.py
+++ b/spond/spond.py
@@ -532,8 +532,8 @@ class Spond(_SpondBase):
                 await self.get_groups()
             entities = self.groups
         else:
-            err_msg = f"Entity type '{entity_type}' is not supported."
-            raise NotImplementedError(err_msg)
+            errmsg = f"Entity type '{entity_type}' is not supported."
+            raise NotImplementedError(errmsg)
 
         errmsg = f"No {entity_type} with id='{uid}'."
         if not entities:

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -535,8 +535,11 @@ class Spond(_SpondBase):
             err_msg = f"Entity type '{entity_type}' is not supported."
             raise NotImplementedError(err_msg)
 
+        errmsg = f"No {entity_type} with id='{uid}'."
+        if not entities:
+            raise KeyError(errmsg)
+
         for entity in entities:
             if entity["id"] == uid:
                 return entity
-        errmsg = f"No {entity_type} with id='{uid}'."
         raise KeyError(errmsg)

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -99,6 +99,21 @@ class TestEventMethods:
             await s.get_event("")
 
     @pytest.mark.asyncio
+    async def test_get_event__no_events_available_raises_keyerror(
+        self, mock_token
+    ) -> None:
+        """`get_events()` is documented to return None when no events exist;
+        `get_event()` should surface this as KeyError, not TypeError."""
+
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+        s.events = None
+        s.get_events = AsyncMock()  # leaves self.events as None
+
+        with pytest.raises(KeyError):
+            await s.get_event("ID1")
+
+    @pytest.mark.asyncio
     @patch("aiohttp.ClientSession.put")
     async def test_change_response(self, mock_put, mock_payload, mock_token) -> None:
         s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
@@ -187,6 +202,21 @@ class TestGroupMethods:
 
         with pytest.raises(KeyError):
             await s.get_group("")
+
+    @pytest.mark.asyncio
+    async def test_get_group__no_groups_available_raises_keyerror(
+        self, mock_token
+    ) -> None:
+        """`get_groups()` is documented to return None when no groups exist;
+        `get_group()` should surface this as KeyError, not TypeError."""
+
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+        s.groups = None
+        s.get_groups = AsyncMock()  # leaves self.groups as None
+
+        with pytest.raises(KeyError):
+            await s.get_group("ID1")
 
 
 class TestExportMethod:


### PR DESCRIPTION
## Summary

- `get_events()` and `get_groups()` are documented to return `None` when no events/groups are available, but `_get_entity()` iterated the returned value directly, crashing with `TypeError: 'NoneType' object is not iterable`.
- Add a single guard: if the cache is empty (None or `[]`) after the refresh attempt, raise the same `KeyError` the function already raises for the "id not in list" case. From the caller's perspective both cases are functionally equivalent — they asked for an id that isn't available.

## TDD verification

Before applying the fix, the new tests reproduce the exact error from the issue:

```
>       for entity in entities:
E       TypeError: 'NoneType' object is not iterable
spond/spond.py:538: TypeError
```

After the fix: 23 tests pass (21 original + 2 new).

## Scope note

The issue comments mention a related-but-distinct failure mode: when the Spond API returns an *authentication error JSON object* (a `dict`) instead of the expected `list[dict]`, the same iteration path produces a different `TypeError` (string-indexing a dict key). That case is a symptom of deeper auth-handling issues elliot-100 noted they're investigating separately. **Not addressed here** — this PR only handles the documented-`None` case in the issue title.

## Test plan

- [x] Local `pytest` — 23 tests pass (was 21)
- [x] Local `ruff check` — clean
- [x] Local `ruff format --check` — clean
- [x] New tests fail without the fix (reproduces exact `TypeError` from #136)
- [ ] CI: full Python matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)