### PR TITLE
docs: add pdoc API documentation + audit docstrings (#216)

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,66 @@
+name: Publish API docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:  # allow manual rebuild without a push
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialize deploys so a fast follow-up push doesn't race a mid-flight deploy.
+# Don't cancel in-progress — half-uploaded artifacts can leave Pages broken.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: 📚 Build docs with pdoc
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Olen'  # skip on forks
+    steps:
+      - name: 🛎️ Checkout repository
+        uses: actions/checkout@v6
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: 🎭 Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: 🏗️ Install project (with dev dependencies for pdoc)
+        run: poetry install
+
+      - name: 📝 Generate static HTML
+        # `./spond` (not `spond`) forces pdoc to document the local checkout
+        # instead of any same-named module that might be importable.
+        run: poetry run pdoc -o site/ ./spond
+
+      - name: ⚙️ Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: 📦 Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    name: 🚀 Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Olen'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: 🌐 Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -91,6 +91,31 @@ Demonstrates most `get...()` methods.
 
 [This article](https://realpython.com/async-io-python/) will give a nice introduction to both why, when and how to use asyncio in projects.
 
+## API documentation
+
+The library's API documentation is generated from the docstrings in `spond/`
+using [pdoc](https://pdoc.dev/). To browse it locally, install the dev
+dependencies and start the pdoc dev server:
+
+```shell
+poetry install
+poetry run pdoc ./spond
+```
+
+A browser tab opens at `http://localhost:8080` with a searchable, navigable
+view of all public modules, classes, and methods, and a "View Source" link
+next to each one. Pages update automatically when the docstrings change.
+
+To generate static HTML instead:
+
+```shell
+poetry run pdoc -o docs/ ./spond
+```
+
+The leading `./` is important when developing inside the repo — without it,
+pdoc would document the *installed* `spond` package from `site-packages`
+rather than your local checkout.
+
 ## Contributing
 
 ### Keeping a PR up to date with `main`

--- a/README.md
+++ b/README.md
@@ -94,8 +94,13 @@ Demonstrates most `get...()` methods.
 ## API documentation
 
 The library's API documentation is generated from the docstrings in `spond/`
-using [pdoc](https://pdoc.dev/). To browse it locally, install the dev
-dependencies and start the pdoc dev server:
+using [pdoc](https://pdoc.dev/) and published to GitHub Pages on every push
+to `main`:
+
+**[https://olen.github.io/Spond/](https://olen.github.io/Spond/)**
+
+To browse the same docs locally (useful when iterating on docstrings),
+install the dev dependencies and start the pdoc dev server:
 
 ```shell
 poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = ">=3.10"
 aiohttp = ">=3.8.5"
 
 [tool.poetry.group.dev.dependencies]
+pdoc = ">=16.0.0"
 pytest = ">=9.0.2"
 pytest-asyncio = ">=1.3.0"
 ruff = ">=0.15.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ python = ">=3.10"
 aiohttp = ">=3.8.5"
 
 [tool.poetry.group.dev.dependencies]
-pdoc = ">=16.0.0"
+# Constraint on `python` is required: pdoc's transitive `markdown2` declares
+# `python<4`, which conflicts with our unbounded `python = ">=3.10"` upper.
+pdoc = {version = ">=16.0.0", python = "<4"}
 pytest = ">=9.0.2"
 pytest-asyncio = ">=1.3.0"
 ruff = ">=0.15.0"

--- a/spond/__init__.py
+++ b/spond/__init__.py
@@ -1,3 +1,9 @@
+"""Unofficial Python SDK for the Spond API.
+
+The main entry point is `spond.spond.Spond` for general account/event/group/
+messaging access, and `spond.club.SpondClub` for the Spond Club finance API.
+"""
+
 from typing import Any, TypeAlias
 
 JSONDict: TypeAlias = dict[str, Any]

--- a/spond/base.py
+++ b/spond/base.py
@@ -16,6 +16,8 @@ class _SpondBase(ABC):
 
     @property
     def auth_headers(self) -> dict:
+        """Headers required for authenticated requests: JSON content-type plus
+        a Bearer token from `self.token`."""
         return {
             "content-type": "application/json",
             "Authorization": f"Bearer {self.token}",
@@ -23,6 +25,10 @@ class _SpondBase(ABC):
 
     @staticmethod
     def require_authentication(func: Callable):
+        """Decorator that calls `self.login()` before invoking `func` if the
+        client is not yet authenticated. On `AuthenticationError`, closes the
+        underlying aiohttp session before re-raising."""
+
         async def wrapper(self, *args, **kwargs):
             if not self.token:
                 try:
@@ -35,6 +41,15 @@ class _SpondBase(ABC):
         return wrapper
 
     async def login(self) -> None:
+        """Authenticate against the Spond API and store the access token on
+        `self.token`. Called automatically by the `require_authentication`
+        decorator; rarely needs to be called explicitly.
+
+        Raises
+        ------
+        AuthenticationError
+            If the server response does not include a usable access token.
+        """
         login_url = f"{self.api_url}auth2/login"
         data = {"email": self.username, "password": self.password}
         async with self.clientsession.post(login_url, json=data) as r:

--- a/spond/club.py
+++ b/spond/club.py
@@ -27,14 +27,14 @@ class SpondClub(_SpondBase):
         club_id : str
             Identifier for the club. Note that this is different from the Group ID used
             in the core API.
-        max_items : int, optional
-            The maximum number of transactions to retrieve. Defaults to 100.
         skip : int, optional
             This endpoint only returns 25 transactions at a time (page scrolling).
             Therefore, we need to increment this `skip` param to grab the next
             25 etc. Defaults to None. It's better to keep `skip` at None
             and specify `max_items` instead. This param is only here for the
-            recursion implementation
+            recursion implementation.
+        max_items : int, optional
+            The maximum number of transactions to retrieve. Defaults to 100.
 
         Returns
         -------

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -322,29 +322,29 @@ class Spond(_SpondBase):
         Parameters
         ----------
         group_id : str, optional
-            Uses `GroupId` API parameter.
+            Uses `groupId` API parameter.
         subgroup_id : str, optional
             Uses `subgroupId` API parameter.
         include_scheduled : bool, optional
-            Include scheduled events.
-            (TO DO: probably events for which invites haven't been sent yet?)
+            Include scheduled events (events whose invitations are queued to be
+            sent in the future).
             Defaults to False for performance reasons.
             Uses `scheduled` API parameter.
         include_hidden : bool, optional
             Include hidden events.
             Uses `includeHidden` API parameter.
-            'includeHidden' filter is only available inside a group
+            'includeHidden' filter is only available inside a group.
         max_end : datetime, optional
             Only include events which end before or at this datetime.
             Uses `maxEndTimestamp` API parameter; relates to `endTimestamp` event
             attribute.
-        max_start : datetime, optional
-            Only include events which start before or at this datetime.
-            Uses `maxStartTimestamp` API parameter; relates to `startTimestamp` event
-            attribute.
         min_end : datetime, optional
             Only include events which end after or at this datetime.
             Uses `minEndTimestamp` API parameter; relates to `endTimestamp` event
+            attribute.
+        max_start : datetime, optional
+            Only include events which start before or at this datetime.
+            Uses `maxStartTimestamp` API parameter; relates to `startTimestamp` event
             attribute.
         min_start : datetime, optional
             Only include events which start after or at this datetime.


### PR DESCRIPTION
## Summary

Closes #216.

Adds an API documentation generator (`pdoc`) and the supporting CI to publish it to GitHub Pages on every push to `main`. Also a focused audit of the public-API docstrings, since pdoc renders them verbatim — any inaccuracies become user-visible the moment we publish.

## Attribution / history

The original suggestion and choice of `pdoc` come from @elliot-100's branch [\`feat/auto-doc\`](https://github.com/Olen/Spond/tree/feat/auto-doc) — but that branch was forked from main back in **February 2026** and never rebased. As of today its diff against main would silently revert:

- the \`/auth2/login\` migration (#230, shipped in v1.2.1),
- the \`meetupTimestamp\` fix in \`examples/ical.py\` (#228),
- the auto-update-prs workflow (#231),
- multiple action-version bumps (\`actions/checkout\` v4→v6, \`actions/setup-python\` v5→v6, \`softprops/action-gh-release\` v2→v3),
- the README sections about \`get_posts()\`, \`get_profile()\`, contributor workflow, and \`manual_test_functions.py\`,
- the \`TestLogin\` test class.

So I rescued the *idea* onto a fresh branch from current main rather than try to rebase. The actual content the branch contributed was tiny (pdoc dev dep + a 6-line README hint); the bulk of this PR is the docstring audit and CI workflow.

## What's in this PR

### 1. Tooling (\`pyproject.toml\`)
- Add \`pdoc = \">=16.0.0\"\` to dev dependencies.

### 2. Where docs live and what they look like

**Hosted (after merge)**: [https://olen.github.io/Spond/](https://olen.github.io/Spond/) — automatically rebuilt on every push to \`main\` by the new workflow. URL hierarchy:
- \`/\` → top-level package index (lists the \`spond\` submodule)
- \`/spond.html\` → \`spond\` package page (shows the new module-level docstring + \`JSONDict\`, \`AuthenticationError\`)
- \`/spond/spond.html\` → \`spond.spond\` module (the main \`Spond\` class + all public methods)
- \`/spond/club.html\` → \`spond.club\` module (\`SpondClub\` + \`get_transactions\`)
- \`/spond/base.html\` → \`spond.base\` module (\`_SpondBase\` private but its public members surface here)

**Look and feel** — pdoc renders a left-nav of all public symbols (private \`_\`-prefixed names are auto-hidden from nav but their source is still accessible), each function/class gets its docstring rendered as Markdown plus a \"View Source\" link inline with the signature. Search index is built into a JS-based filter box at the top.

**Locally**: \`poetry run pdoc ./spond\` opens \`http://localhost:8080\` with the same view, but live-reloads on docstring edits — useful when iterating.

### 3. CI workflow (\`.github/workflows/publish-docs.yml\`)

- Triggers on \`push\` to \`main\` and on \`workflow_dispatch\` (manual rebuild).
- Uses the modern artifact-based Pages deployment: \`actions/configure-pages\` + \`actions/upload-pages-artifact\` + \`actions/deploy-pages\`. No \`gh-pages\` branch, no commits pushed back to main, deploys are atomic.
- Concurrency: serialized on the \`pages\` group with \`cancel-in-progress: false\` so a fast follow-up push doesn't race a mid-flight deploy and leave Pages partially uploaded.
- Both jobs gated on \`github.repository_owner == 'Olen'\` so forks don't fail trying to deploy to Pages they don't control.

### ⚙️ One-time settings step required

Before the deploy will succeed, **GitHub Pages needs to be enabled** at Settings → Pages → Source = \"GitHub Actions\". This is a one-time toggle per repo and not configurable via the workflow file. Until that's flipped, the \`Build\` job will succeed but \`Deploy\` will fail at \`actions/configure-pages\`. After flipping, just re-run the workflow once via the Actions tab.

### 4. Docstring audit

pdoc-driven pass over the public API. Fixed:

| File | Symbol | Issue |
|---|---|---|
| \`__init__.py\` | (module) | No module-level docstring → pdoc landing page was empty. Added one. |
| \`base.py\` | \`auth_headers\` | Property had no docstring despite being part of the inherited public surface. |
| \`base.py\` | \`require_authentication\` | Decorator was undocumented. |
| \`base.py\` | \`login()\` | Public method, no docstring. Now documents it, the \`AuthenticationError\` it raises, and that \`require_authentication\` calls it implicitly. |
| \`spond.py\` | \`get_events\` | Docstring said \`GroupId\` (uppercase) but the actual API param is \`groupId\` (line 384). Stray \`(TO DO: probably events for which invites haven't been sent yet?)\` removed and replaced with a concrete description of scheduled events. Parameter block reordered so \`max_end, min_end, max_start, min_start\` matches the function signature instead of \`max_end, max_start, min_end, min_start\`. |
| \`club.py\` | \`get_transactions\` | Docstring parameter order was \`club_id, max_items, skip\` but the signature is \`club_id, skip, max_items\` — reordered to match. |

### 5. Latent code bugs noticed (not fixed here)

Worth separate issues — flagging so they don't get lost:

- \`send_message\` (\`spond.py:285\`) is missing \`await\` on \`self._continue_chat(chat_id, text)\`. Also annotated \`-> JSONDict\` but can return \`False\` (line 295).
- \`update_event\` (\`spond.py:454-455\`) saves the API response to \`self.events_update\` but then \`return self.events\` — returns the unrelated cached list instead of the update result. Docstring says \"json results of post command\" which matches the *intended* behavior, so the bug is in the code, not the docstring.

## Test plan

- [x] Local \`pytest\` — 23 tests pass
- [x] Local \`ruff check\` — clean
- [x] Local \`ruff format --check\` — clean (with ruff 0.15.12)
- [x] Local \`pdoc -o /tmp/pdoc-out ./spond\` — generates the expected file tree, new module-level docstring visible on \`spond.html\`, all base.py docstrings render, \`get_events\` param order matches signature
- [x] Smoke-tested \`import spond\` — module-level docstring loads, \`AuthenticationError\` docstring intact
- [ ] CI: Python package matrix + new Publish API docs workflow (will need the Pages settings flip before Deploy can succeed)
- [ ] Post-merge verification: visit https://olen.github.io/Spond/ and confirm docs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)