### PR TITLE
ci: drop Python 3.10 from CI matrix and minimum version (#240)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Check out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = 'README.md'
 repository = 'https://github.com/Olen/Spond'
 
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.11"
 aiohttp = ">=3.8.5"
 
 [tool.poetry.group.dev.dependencies]
@@ -25,7 +25,7 @@ ruff = ">=0.15.0"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
-target-version = "py310"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
+target-version = "py311"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

Closes #240. Python 3.10 reaches EOL in October 2026 (~5 months from now). This PR drops it from **both** the CI matrix and \`pyproject.toml\`'s minimum, so the package doesn't claim support for a version we no longer test against.

## Changes

- \`.github/workflows/python-package.yml\` — matrix becomes \`["3.11", "3.12", "3.13", "3.14"]\`.
- \`pyproject.toml\` — \`python = ">=3.10"\` → \`">=3.11"\`, \`tool.ruff.target-version\` = \`"py310"\` → \`"py311"\`.

## What `ruff check --fix` did

**Nothing**. The codebase was already using modern syntax (PEP 604 unions like \`X | None\`, \`from __future__ import annotations\` everywhere, no \`typing.Optional\` or \`typing.Union\` left), so bumping the target version unlocks future rule additions but doesn't rewrite anything today. Net diff: 3 insertions, 3 deletions across 2 files.

## Why bundle pyproject + workflow in one PR

If we dropped 3.10 from CI but left \`python = ">=3.10"\` in pyproject, the package would still **claim** to support a version we no longer test — and a 3.10-specific regression could land silently. Either drop both, or drop neither.

## Side benefit

The smallest matrix entry was contributing to today's earlier transient CI failure on #241 (ruff 0.15.13 was published with wheels for 3.12/3.14 but not yet for 3.10/3.11/3.13). Dropping 3.10 doesn't fix that class of issue entirely, but it does shrink the matrix by 20% which means one fewer chance of hitting a partial-wheel-rollout edge case.

## Test plan

- [x] Local \`pytest\` — 23 tests pass
- [x] Local \`ruff check\` — clean (target now \`py311\`)
- [x] Local \`ruff format --check\` — clean
- [x] Local \`ruff check --fix\` — no changes proposed (code already modern enough)
- [ ] CI: 4-version matrix green
- [ ] Merge order: this PR first, then rebase #241 on top to pick up the 4-version matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)