### PR TITLE
fix: preserve wrapped method metadata in require_authentication

### DIFF
--- a/spond/base.py
+++ b/spond/base.py
@@ -8,6 +8,7 @@ flow used by the `require_authentication` decorator.
 Not intended to be instantiated directly — use a subclass.
 """
 
+import functools
 from abc import ABC
 from collections.abc import Callable
 
@@ -65,6 +66,7 @@ class _SpondBase(ABC):
         client is not yet authenticated. On `AuthenticationError`, closes the
         underlying aiohttp session before re-raising."""
 
+        @functools.wraps(func)
         async def wrapper(self, *args, **kwargs):
             if not self.token:
                 try:

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -450,3 +450,32 @@ class TestLogin:
         with pytest.raises(AuthenticationError):
             await s.login()
         assert s.token is None
+
+
+class TestRequireAuthenticationDecorator:
+    """The `require_authentication` decorator must preserve the wrapped
+    method's metadata (signature, docstring, name) so `inspect`-based
+    tools — pdoc, IDE help, tab completion — see the real method
+    rather than the wrapper's `(*args, **kwargs)` shim.
+    """
+
+    def test_decorator_preserves_signature(self) -> None:
+        """Decorated methods must expose their real parameter list."""
+        import inspect
+
+        # `get_posts` is decorated and has a distinctive signature
+        params = list(inspect.signature(Spond.get_posts).parameters)
+        assert params == ["self", "group_id", "max_posts", "include_comments"]
+
+    def test_decorator_preserves_docstring(self) -> None:
+        """Decorated methods must expose their own docstring, not the
+        wrapper's."""
+        import inspect
+
+        doc = inspect.getdoc(Spond.get_profile) or ""
+        # Wrapper docstring would start with 'Decorator that...' if leaked.
+        assert "Retrieve the authenticated user's profile." in doc
+
+    def test_decorator_preserves_name(self) -> None:
+        """`__name__` must be the method's, not 'wrapper'."""
+        assert Spond.get_events.__name__ == "get_events"


### PR DESCRIPTION
## The bug

You're right — the function-level docstrings on https://olen.github.io/Spond/spond/spond.html are wrong, but the cause isn't in the docstrings themselves. The \`require_authentication\` decorator was missing \`@functools.wraps(func)\`, so every method it decorated lost its metadata:

\`\`\`python
# before
@staticmethod
def require_authentication(func: Callable):
    async def wrapper(self, *args, **kwargs):
        ...
    return wrapper
\`\`\`

Without \`functools.wraps\`, \`Spond.get_profile\` was internally just a copy of \`wrapper\`. \`inspect.signature\` saw \`(self, *args, **kwargs)\`. \`inspect.getdoc\` saw nothing (or the wrapper's docstring leaked through, depending on Python's exact resolution). pdoc reads both, so every decorated method on the live site rendered as:

\`\`\`
async def get_profile(self, *args, **kwargs):
    # source: the wrapper's body, not get_profile's
\`\`\`

instead of:

\`\`\`
async def get_profile(self) -> JSONDict:
    """Retrieve the authenticated user's profile.

    The profile dict includes at least the user's \`id\`, \`firstName\`, and
    \`lastName\`...
    """
\`\`\`

All my docstring work from #237 / #241 landed in source but pdoc never saw it for decorated methods.

## The fix

Two lines: \`import functools\` + \`@functools.wraps(func)\` on the inner wrapper. After this fix, decorated methods expose their real signatures and docstrings:

\`\`\`
get_profile(self) -> 'JSONDict'
  → Retrieve the authenticated user's profile.
get_posts(self, group_id: 'str | None' = None, max_posts: 'int' = 20, ...
  → Retrieve posts from group walls.
get_events(self, group_id: 'str | None' = None, subgroup_id: 'str | None' = None, ...
  → Retrieve events visible to the authenticated user.
\`\`\`

## Regression tests

New \`TestRequireAuthenticationDecorator\` class with three tests that each fail if \`functools.wraps\` is removed:

- \`test_decorator_preserves_signature\` — \`get_posts\` exposes its real parameter list, not \`*args, **kwargs\`.
- \`test_decorator_preserves_docstring\` — \`get_profile\` exposes its real docstring, not the wrapper's.
- \`test_decorator_preserves_name\` — \`get_events.__name__\` is \`"get_events"\`, not \`"wrapper"\`.

## Why this only surfaced now

Before #241 expanded the docstrings, all decorated methods had thin one-line docstrings. The wrapper's "leaked" appearance was less obvious because the user-facing docs were already terse. After #241 dropped substantial docstrings on each method, the bug became loud: I had carefully written content for, say, \`get_events\`, and pdoc kept showing a generic \`(self, *args, **kwargs)\` shim instead.

## Test plan

- [x] Local \`pytest\` — 30 tests pass (27 inherited from #243 + 3 new wraps regression tests)
- [x] Local \`ruff check\` — clean
- [x] Local \`ruff format --check\` — clean
- [x] Local \`pdoc -o /tmp ./spond\` — decorated methods now render with real signatures and docstrings
- [ ] CI: 4-version matrix green
- [ ] Post-merge: GitHub Pages rebuilds; visit https://olen.github.io/Spond/spond/spond.html and confirm the function-level docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)