### PR TITLE
build(deps): require aiohttp >=3.14.3 for security advisories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ repository = 'https://github.com/Olen/Spond'
 
 [tool.poetry.dependencies]
 python = ">=3.11"
-aiohttp = ">=3.8.5"
+# Floor is a security boundary, not a feature requirement: everything below
+# 3.14.3 carries known advisories in the HTTP parsers, up to and including a
+# high-severity out-of-bounds read (CVE-2026-69244). As a library we publish
+# this range to downstream installs, so it must not resolve to a vulnerable
+# aiohttp. Don't lower it without checking the advisories first.
+aiohttp = ">=3.14.3"
 
 [tool.poetry.group.dev.dependencies]
 # Constraint on `python` is required: pdoc's transitive `markdown2` declares


### PR DESCRIPTION
## Summary

Raises the `aiohttp` dependency floor from `>=3.8.5` to `>=3.14.3`, closing all 14 open Dependabot alerts on this repository.

## Why the alerts were stuck

Every open security alert on the repo is aiohttp — 1 high, 8 medium, 5 low. None of them ever produced a Dependabot PR, and that is a consequence of how the constraint was written rather than an oversight in configuration (the `pip` ecosystem *is* enabled in `.github/dependabot.yml`).

Dependabot's security updater only opens a PR when the manifest **forbids** the patched version. `>=3.8.5` already permitted 3.14.3, so there was no edit for it to make — while simultaneously telling every downstream consumer that resolving to a vulnerable aiohttp is acceptable. With no committed lockfile (`poetry.lock` is gitignored, correct for a library), this declared range is the only version signal consumers get.

The highest-severity item is CVE-2026-69244: an out-of-bounds heap read in the C HTTP response parser when handling a malformed chunked response, exploitable by a server the client talks to. Practical exposure for this library is limited, since it speaks only to `api.spond.com` — but that safety rests on trusting that endpoint and the network path to it, which is not something worth encoding as a dependency floor.

## Compatibility

The floor moves a long way, so it is worth being explicit about who it affects: the package already requires Python >=3.11 and CI covers 3.11–3.14, all of which aiohttp 3.14.3 supports. The constraint is a lower bound only, so consumers already on a recent aiohttp are unaffected. Consumers deliberately pinned below 3.14.3 will need to upgrade.

The floor is commented in `pyproject.toml`, matching the file's existing convention of documenting non-obvious constraints, so it isn't lowered inadvertently later.

## Testing

Full CI sequence run locally under Poetry, against the newly resolved aiohttp 3.14.3:

- `poetry install` → resolves aiohttp 3.14.3
- `poetry run ruff check` → all checks passed
- `poetry run ruff format --check --diff` → 13 files already formatted
- `poetry run pytest` → 30 passed

One note: the suite emits an `Unclosed client session` warning. I verified this is pre-existing test hygiene and unrelated to this change by re-running the suite against aiohttp 3.13.3, which produces the identical warning. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)