### PR TITLE
docs: document the aiohttp version requirement and its rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Simple, unofficial library with some example scripts to access data from the [Sp
 
 `pip install spond`
 
+### Requirements
+
+- Python 3.11 or later
+- `aiohttp` 3.14.3 or later
+
+The `aiohttp` floor is a security requirement rather than a feature one. Releases
+below 3.14.3 carry known advisories in the HTTP parsers, the most serious being an
+out-of-bounds read in the C response parser that an upstream server can trigger with
+a malformed chunked response ([CVE-2026-69244](https://github.com/advisories/GHSA-cq5v-8q36-5273)).
+If you pin `aiohttp` in your own project, pin it at or above 3.14.3.
+
 ## Usage
 
 You need a username and password from Spond


### PR DESCRIPTION
## Summary

Follow-up to #254, which raised the `aiohttp` floor to `>=3.14.3` to clear 14 outstanding security advisories.

Adds a `Requirements` subsection under `Install` recording both supported-version facts (Python >=3.11, aiohttp >=3.14.3) and, for aiohttp, *why* the floor is where it is — an out-of-bounds read in the C response parser triggerable by a malformed chunked response (CVE-2026-69244), plus other parser advisories.

The rationale is the point of the note. Without it the floor reads as an arbitrary version preference, and the failure mode is a consumer pinning `aiohttp` below 3.14.3 in their own project and silently reintroducing the vulnerability. Placing it beside the install instructions puts it where someone who pins their own dependencies will meet it before making that choice, rather than after.

## Testing

Documentation-only change; no source or packaging files touched. CI sequence run locally regardless:

- `poetry run ruff check` → all checks passed
- `poetry run ruff format --check` → 13 files already formatted
- `poetry run pytest` → 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)