### PR TITLE
test: block outbound network access from the test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,25 @@ aiohttp = ">=3.14.3"
 pdoc = {version = ">=16.0.0", python = "<4"}
 pytest = ">=9.0.2"
 pytest-asyncio = ">=1.3.0"
+pytest-socket = ">=0.7.0"
 ruff = ">=0.15.0"
 
 [tool.pytest.ini_options]
 # Pinned explicitly: pytest-asyncio's default is currently unset and will
 # flip to "function" in a future release — set now so behaviour can't drift.
 asyncio_default_fixture_loop_scope = "function"
+# The suite is fully mocked and must never reach the network. Without this, a
+# gap in a mock doesn't fail — it sends a real request to api.spond.com, which
+# is slow, non-deterministic, dependent on credentials CI doesn't have, and
+# capable of passing for the wrong reason.
+#
+# `--allow-unix-socket` is required, not optional: asyncio builds its event
+# loop self-pipe with `socket.socketpair()` (AF_UNIX on Linux), so blocking
+# every socket would break the event loop and with it every async test.
+#
+# A test that genuinely needs the network must opt in explicitly with
+# `@pytest.mark.enable_socket`.
+addopts = "--disable-socket --allow-unix-socket"
 
 [tool.ruff]
 target-version = "py311"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary

Adds `pytest-socket` and disables sockets for the whole suite, so a gap in a mock fails immediately instead of sending a real request to `api.spond.com`.

## Motivation

This is not hypothetical. CI on #236 currently fails like this:

```
ValueError: Request failed with status 401: {"message":"User is not logged in.","errorKey":"notLoggedIn"}
```

That JSON came from the production Spond API — a GitHub Actions runner made a real outbound call because a change moved `_get_entity()` onto an HTTP path that the test's mocks did not cover. The test failed for the right reason there, but only by luck: an unmocked request that happens to succeed passes the test for entirely the wrong reason, and the result depends on network conditions and credentials CI does not have.

Under this guard the same situation fails immediately and legibly:

```
pytest_socket.SocketBlockedError: A test tried to use socket.getaddrinfo.
```

## Why `pytest-socket` rather than a `conftest.py` fixture

A hand-rolled guard typically patches `socket.socket.connect`, which has real gaps: aiohttp resolves DNS through `loop.getaddrinfo` before connecting, and asyncio connects non-blocking sockets via the selector. A guard with holes is worse than no guard, because it manufactures false confidence. `pytest-socket` intercepts at socket creation and `getaddrinfo`, which is where the traffic actually starts.

## Why `--allow-unix-socket`

Load-bearing, not decoration. asyncio's `BaseSelectorEventLoop` builds its self-pipe with `socket.socketpair()`, which is `AF_UNIX` on Linux. Blocking every socket unconditionally breaks the event loop itself, and with it every async test in the suite.

## Escape hatch

A test that genuinely needs the network can opt in with `@pytest.mark.enable_socket`. Nothing in the suite currently does.

## Testing

- `poetry run pytest` → 30 passed with the guard active, confirming the existing suite is already hermetic and the AF_UNIX exception is correct
- Deliberately verified the guard bites: a temporary test issuing a real `aiohttp` GET to `https://api.spond.com/...` was blocked at `socket.getaddrinfo` with `SocketBlockedError` naming the host. Probe removed before commit
- `poetry run ruff check` → all checks passed
- `poetry run ruff format --check` → 13 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)