### PR TITLE
build(deps): make the aiohttp floor a compatibility bound, not a security one

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Simple, unofficial library with some example scripts to access data from the [Sp
 ### Requirements
 
 - Python 3.11 or later
-- `aiohttp` 3.14.3 or later
+- `aiohttp` 3.13.0 or later
 
-The `aiohttp` floor is a security requirement rather than a feature one. Releases
-below 3.14.3 carry known advisories in the HTTP parsers, the most serious being an
-out-of-bounds read in the C response parser that an upstream server can trigger with
-a malformed chunked response ([CVE-2026-69244](https://github.com/advisories/GHSA-cq5v-8q36-5273)).
-If you pin `aiohttp` in your own project, pin it at or above 3.14.3.
+The `aiohttp` bound is a compatibility floor, not a security one — which
+advisories matter depends on your application, so pinning is your call. For
+reference: releases below 3.14.3 carry known HTTP-parser advisories, the most
+serious being [CVE-2026-69244](https://github.com/advisories/GHSA-cq5v-8q36-5273).
+Installing without a pin already gives you the newest `aiohttp`.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,9 @@ repository = 'https://github.com/Olen/Spond'
 
 [tool.poetry.dependencies]
 python = ">=3.11"
-# Floor is a security boundary, not a feature requirement: everything below
-# 3.14.3 carries known advisories in the HTTP parsers, up to and including a
-# high-severity out-of-bounds read (CVE-2026-69244). As a library we publish
-# this range to downstream installs, so it must not resolve to a vulnerable
-# aiohttp. Don't lower it without checking the advisories first.
-aiohttp = ">=3.14.3"
+# Compatibility floor, not a security one: 3.13.0 is the oldest aiohttp
+# supporting Python 3.14. Security pinning is left to consumers (see README).
+aiohttp = ">=3.13.0"
 
 [tool.poetry.group.dev.dependencies]
 # Constraint on `python` is required: pdoc's transitive `markdown2` declares


### PR DESCRIPTION
## Summary

Walks back the `aiohttp` floor from #254 and re-derives it on compatibility grounds. Sets `>=3.13.0`.

## Why

@elliot-100 pushed back on #254's reasoning, and the objection is correct: a library's dependency bounds state what it needs to function, not a security policy. Which advisories matter depends on the consuming application, so the pin belongs to them. A floor at the newest patch release forces an upgrade on everyone and sits one advisory away from needing the next bump.

The second objection also lands. #254 argued the range was "the only version signal" *because* no lockfile is committed — but a lockfile never reaches consumers at all, so it could never be that signal either way. The conclusion was accidentally true; the reasoning was not.

## Why `>=3.13.0` rather than back to `>=3.8.5`

`>=3.8.5` was itself incorrect, in the opposite direction. This package requires `python>=3.11`, but aiohttp 3.8.5 declares support only through Python 3.10 — no install could satisfy both bounds.

3.13.0 is the oldest aiohttp declaring Python 3.14 support, which this package tests against. From PyPI classifiers:

| aiohttp | Python support |
|---------|----------------|
| 3.8.5 | ≤ 3.10 |
| 3.12.15 | ≤ 3.13 |
| **3.13.0** | **≤ 3.14** ✅ |

## This clears zero alerts, deliberately

Every one of the 14 advisories needs `>=3.14.0` at minimum, so no compatibility-justified floor clears any of them. That separation is the point: compatibility belongs in the manifest, security guidance belongs in the README as advice.

The alerts are better handled by dismissing them with a rationale than by constraining consumers.

## README

Reframed from requirement to advice: the CVE reference stays for consumers deciding their own pin, without imposing it.

## Testing

- `poetry run pytest` against **aiohttp 3.13.0** (the new floor) → 30 passed
- `poetry run pytest` against 3.14.3 (current resolution) → 30 passed
- `poetry run ruff check` → passed; `ruff format --check` → 13 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)