### PR TITLE
build: pin ruff exactly and exclude Markdown from the formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ pdoc = {version = ">=16.0.0", python = "<4"}
 pytest = ">=9.0.2"
 pytest-asyncio = ">=1.3.0"
 pytest-socket = ">=0.7.0"
-ruff = ">=0.15.0"
+# Pinned exactly: CI resolves fresh, so a floating formatter changes the verdict
+# on untouched branches. Dependabot raises upgrades as their own PR.
+ruff = "==0.16.3"
 
 [tool.pytest.ini_options]
 # Pinned explicitly: pytest-asyncio's default is currently unset and will
@@ -44,6 +46,10 @@ addopts = "--disable-socket --allow-unix-socket"
 
 [tool.ruff]
 target-version = "py311"  # Ruff doesn't yet infer this from [tool.poetry.dependencies]
+
+[tool.ruff.format]
+# Docs snippets are illustrative, not compiled: keep hand-alignment readable.
+exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

Pins `ruff` to `==0.16.3` and excludes `*.md` from the formatter.

## Why pin

ruff 0.16 began formatting Python code blocks inside Markdown; 0.15 did not. With a `>=0.15.0` floor and fresh resolution in CI, that turned #246 red without any change to the branch — the same commit passed in May and failed in August.

A floating formatter means a commit's CI verdict is not stable over time. On a repo with 41 forks that lands asymmetrically: an outside contributor's PR goes red for something unrelated to their change, and the fix gets bundled into whatever work happened to be in flight.

Pinning does **not** stall upgrades. An exact pin is precisely the case where Dependabot opens a PR — a `>=` floor gives it nothing to edit, which is why it has never proposed a ruff bump. So new versions still arrive and still flag latent issues; they just arrive as their own reviewable change.

Dev-only dependency, so nothing is imposed on downstream consumers.

## Why exclude Markdown

Doc snippets are illustrative rather than compiled, and the formatter collapses hand-aligned trailing comments that make the examples scannable:

```python
    SpondError,             # base — catch this for any SDK error    ← before
    SpondError,  # base — catch this for any SDK error               ← after
```

Scoped to `[tool.ruff.format]`, so linting is unaffected.

## Testing

- `poetry run ruff format --check` → 12 files (was 13; README.md now excluded)
- `poetry run ruff check` → all checks passed
- `poetry run pytest` → 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)