### PR TITLE
ci: skip the release instead of failing it when the version is unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,22 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "🔢 Extracted version: $VERSION"
 
+      # Any pyproject.toml edit triggers this workflow, but only a version bump
+      # is a release. An unchanged version is a no-op, not a failure — so record
+      # it as an output and skip the remaining steps rather than exiting 1.
       - name: 🔍 Check if Git tag exists
         id: check_tag
         run: |
           if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
-            echo "⚠️ Tag v${VERSION} already exists. Skipping release!"
-            exit 1
+            echo "⚠️ Tag v${VERSION} already exists. Nothing to release."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "🆕 No tag v${VERSION} yet. Releasing."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: "🏷️ Create new tag"
+        if: steps.check_tag.outputs.exists == 'false'
         uses: rickstaa/action-create-tag@v1
         id: "tag_create"
         with:
@@ -62,6 +69,7 @@ jobs:
           message: "✅ Tag Version v${{ env.VERSION }} created"
 
       - name: 🚀 Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}
@@ -71,8 +79,10 @@ jobs:
           prerelease: false
 
       - name: 🏗️ Build package with Poetry
+        if: steps.check_tag.outputs.exists == 'false'
         run: poetry build
 
       - name: 🚀 Publish to PyPI with OpenID
+        if: steps.check_tag.outputs.exists == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
 


### PR DESCRIPTION
## Summary

`release.yml` now ends green and skips the release steps when the version is unchanged, instead of exiting 1.

## Why

The workflow triggers on any push to `main` touching `pyproject.toml`, but only a *version bump* is actually a release. The tag check handled the non-release case with `exit 1`, so every dependency or config edit produced a red run:

```
success  🔍 Extract version from Poetry     → 1.2.1
failure  🔍 Check if Git tag exists         → exit 1, tag v1.2.1 exists
skipped  🏷️ Create new tag
skipped  🚀 Create GitHub Release
skipped  🏗️ Build package with Poetry
skipped  🚀 Publish to PyPI with OpenID
```

Six such runs today, and the same pattern back in May. The guard was working correctly — nothing was ever published, and PyPI still shows 1.2.1 from 2026-05-14 — but a benign "nothing to release" was indistinguishable from a genuinely broken release. That trains everyone to ignore red runs on the one workflow where red should mean something.

## Change

The check records `exists=true|false` as a step output, and the tag / GitHub release / build / publish steps are gated on it.

The condition is `== 'false'` rather than `!= 'true'` deliberately: if the check step ever errors without setting an output, the publish steps skip rather than proceed. Failing closed is the right default for a publish.

## Behaviour

| Situation | Before | After |
|---|---|---|
| `pyproject.toml` edited, version unchanged | ❌ red, nothing published | ✅ green, release steps skipped |
| Version bumped to a new value | ✅ tag + release + publish | ✅ unchanged |

## Testing

Workflow YAML validated and step guards confirmed:

```
—                                            🔍 Check if Git tag exists
steps.check_tag.outputs.exists == 'false'    🏷️ Create new tag
steps.check_tag.outputs.exists == 'false'    🚀 Create GitHub Release
steps.check_tag.outputs.exists == 'false'    🏗️ Build package with Poetry
steps.check_tag.outputs.exists == 'false'    🚀 Publish to PyPI with OpenID
```

Note this PR does not touch `pyproject.toml`, so merging it will not itself trigger the release workflow — the first real exercise will be the next `pyproject.toml` change to land on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)