### PR TITLE
feat: add get_lineups() and get_formations()

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Either specify an existing `chat_id`, or both `user` and `group_uid` for a new c
 ### get_event_attendance_xlsx()
 Get Excel attendance report for a single event, available via the web client.
 
+### get_lineups(uid)
+Get the line-ups set for a match event, including each player's normalised pitch coordinates and the substitutes.
+Line-ups are created in the Spond mobile app and are not rendered by the web client.
+They carry `HOSTS_AND_ADMINS_ONLY` visibility, so they are readable only by an event's hosts and admins.
+
+### get_formations()
+Get Spond's catalogue of formation templates, used to resolve the `formationId` from `get_lineups()` to a name such as `4-4-2`.
+
 ### change_response()
 Change a member's response for an event (e.g. accept/decline)
 
@@ -87,6 +95,9 @@ Generates an ics-file of upcoming events.
 
 ### groups.py
 Generates a json-file for each group you are a member of.
+
+### lineups.py
+Prints a text pitch diagram of the line-up for each match event that has one, using the players' normalised coordinates.
 
 ### attendance.py &lt;-f from_date&gt; &lt;-t to_date&gt; [-a]
 Generates a csv-file for each event between `from_date` and `to_date` with attendance status of all organizers.  The optional parameter `-a` also includes all members that has been invited.

--- a/examples/lineups.py
+++ b/examples/lineups.py
@@ -1,0 +1,85 @@
+import asyncio
+
+from config import password, username
+
+from spond import spond
+
+PITCH_WIDTH = 62
+PITCH_HEIGHT = 21
+LABEL_MAX = 11
+
+
+def first_name(entry: dict) -> str:
+    """First name of an assigned player, or a dash for an unfilled slot.
+
+    A line-up can hold positions with no player assigned; those carry only
+    coordinates, so `playerName` may be empty or missing entirely.
+    """
+    parts = (entry.get("playerName") or "").split()
+    return parts[0] if parts else "-"
+
+
+def pitch_rows(players: list[dict]) -> list[str]:
+    """Lay players out on a text grid using their normalised coordinates.
+
+    `x` and `y` both run 0.0-1.0, with `y` measured from the opponent's goal,
+    so row 0 is the attacking end and the last row is the team's own goal.
+    """
+    grid = [[" "] * PITCH_WIDTH for _ in range(PITCH_HEIGHT)]
+    filled = set()
+
+    def place(row: int, col: int, label: str) -> None:
+        """Write `label`, nudging it aside if that cell is already occupied."""
+        for row_offset, col_offset in ((0, 0), (-1, 0), (1, 0), (0, 2), (0, -2)):
+            r, c = row + row_offset, col + col_offset
+            if not (0 <= r < PITCH_HEIGHT and 0 <= c <= PITCH_WIDTH - len(label)):
+                continue
+            if any((r, c + i) in filled for i in range(len(label) + 1)):
+                continue
+            for i, char in enumerate(label):
+                grid[r][c + i] = char
+                filled.add((r, c + i))
+            return
+
+    # Deepest players first, so the goalkeeper keeps its cell in a collision.
+    for player in sorted(players, key=lambda p: p["y"], reverse=True):
+        label = first_name(player)[:LABEL_MAX]
+        row = round(player["y"] * (PITCH_HEIGHT - 1))
+        col = round(player["x"] * (PITCH_WIDTH - 1)) - len(label) // 2
+        place(row, max(0, min(col, PITCH_WIDTH - len(label))), label)
+
+    halfway = PITCH_HEIGHT // 2
+    grid[halfway] = ["-" if char == " " else char for char in grid[halfway]]
+    return ["".join(row) for row in grid]
+
+
+async def main() -> None:
+    s = spond.Spond(username=username, password=password)
+
+    formations = {f["id"]: f for f in await s.get_formations()}
+    events = await s.get_events(max_events=100) or []
+
+    for event in events:
+        if not event.get("matchEvent"):
+            continue
+        for lineup in await s.get_lineups(event["id"]):
+            formation = formations.get(lineup.get("formationId"))
+            print(f"\n{event['heading']} - {event['startTimestamp'][:10]}")
+            print(
+                f"{lineup['name']}: "
+                f"{formation['name'] if formation else 'no formation template'}"
+            )
+            print("+" + "-" * PITCH_WIDTH + "+  attacking")
+            for row in pitch_rows(lineup["players"]):
+                print(f"|{row}|")
+            print("+" + "-" * PITCH_WIDTH + "+  own goal")
+            substitutes = [first_name(p) for p in lineup["substitutes"]]
+            if substitutes:
+                print(f"Substitutes: {', '.join(substitutes)}")
+
+    await s.clientsession.close()
+
+
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+asyncio.run(main())

--- a/spond/spond.py
+++ b/spond/spond.py
@@ -92,6 +92,7 @@ class Spond(_SpondBase):
         self.posts: list[JSONDict] | None = None
         self.messages: list[JSONDict] | None = None
         self.profile: JSONDict | None = None
+        self.formations: list[JSONDict] | None = None
 
     async def _login_chat(self) -> None:
         """Perform the secondary handshake with Spond's chat server.
@@ -636,6 +637,71 @@ class Spond(_SpondBase):
         url = f"{self.api_url}sponds/{uid}/export"
         async with self.clientsession.get(url, headers=self.auth_headers) as r:
             return await r.read()
+
+    @_SpondBase.require_authentication
+    async def get_lineups(self, uid: str) -> list[JSONDict]:
+        """Retrieve the line-ups set for a match event.
+
+        Line-ups are created in the Spond mobile app. The web client does not
+        render them, but the data is returned by the same consumer API and
+        needs no special headers or client identification.
+
+        Each line-up carries `visibility: "HOSTS_AND_ADMINS_ONLY"`, indicating
+        that line-ups are readable only by an event's hosts and admins.
+
+        Parameters
+        ----------
+        uid : str
+            UID of the event whose line-ups to fetch.
+
+        Returns
+        -------
+        list[JSONDict]
+            One dict per line-up; an event may hold several. Each contains
+            `id`, `spondId`, `name`, `activityType`, `visibility`, `players`
+            and `substitutes`. Empty list if no line-up has been set.
+
+            Entries in `players` always carry normalised pitch coordinates
+            `x` and `y` in the range 0.0-1.0, where `y` runs from the
+            opponent's goal at 0.0 to the team's own goal at 1.0.
+
+            A slot with a player assigned to it also carries a `membershipId`
+            (matching a member `id` from `get_groups()`) and a `playerName`.
+            Both are optional: an unfilled slot in the formation omits
+            `membershipId` entirely, and its `playerName` is an empty string
+            or absent. `substitutes` entries carry `membershipId` and
+            `playerName` on the same optional basis, without coordinates.
+
+            `formationId` is present only when a formation template was
+            applied, and absent when the players were positioned freely.
+            Where present, resolve it against `get_formations()`.
+        """
+        url = f"{self.api_url}sponds/{uid}/lineups"
+        async with self.clientsession.get(url, headers=self.auth_headers) as r:
+            return await r.json()
+
+    @_SpondBase.require_authentication
+    async def get_formations(self) -> list[JSONDict]:
+        """Retrieve Spond's catalogue of formation templates.
+
+        A static reference list, identical for all groups, used to resolve the
+        `formationId` from `get_lineups()` to a readable formation name. The
+        full response is cached on `self.formations`.
+
+        Returns
+        -------
+        list[JSONDict]
+            One dict per formation, each with `id`, `name` (e.g. `"4-4-2"`),
+            `teamSize`, and a `positions` list of `{name, x, y}` holding the
+            template's default coordinates.
+
+            Note that each position's `name` is a localisation key such as
+            `"lineup_football_goalkeeper"`, not a display string.
+        """
+        url = f"{self.api_url}lineups/formations"
+        async with self.clientsession.get(url, headers=self.auth_headers) as r:
+            self.formations = await r.json()
+            return self.formations
 
     @_SpondBase.require_authentication
     async def change_response(self, uid: str, user: str, payload: JSONDict) -> JSONDict:

--- a/tests/test_spond.py
+++ b/tests/test_spond.py
@@ -319,6 +319,109 @@ class TestExportMethod:
         assert data == mock_binary
 
 
+class TestLineupMethods:
+    MOCK_LINEUPS: list[JSONDict] = [
+        {
+            "id": "LID1",
+            "spondId": "ID1",
+            "name": "Starting line-up",
+            "activityType": "football",
+            "visibility": "HOSTS_AND_ADMINS_ONLY",
+            "formationId": "FID1",
+            "players": [
+                {
+                    "playerName": "Player One",
+                    "membershipId": "MID1",
+                    "x": 0.5,
+                    "y": 0.9,
+                },
+                {
+                    "playerName": "Player Two",
+                    "membershipId": "MID2",
+                    "x": 0.2,
+                    "y": 0.72,
+                },
+            ],
+            "substitutes": [{"playerName": "Player Three", "membershipId": "MID3"}],
+        },
+    ]
+
+    MOCK_FORMATIONS: list[JSONDict] = [
+        {
+            "id": "FID1",
+            "name": "4-4-2",
+            "teamSize": 11,
+            "positions": [
+                {"name": "lineup_football_goalkeeper", "x": 0.5, "y": 0.9},
+                {"name": "lineup_football_left_back", "x": 0.2, "y": 0.72},
+            ],
+        },
+    ]
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_lineups__happy_path(self, mock_get, mock_token) -> None:
+        """Test that get_lineups returns the event's line-ups."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = True
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value=self.MOCK_LINEUPS
+        )
+
+        lineups = await s.get_lineups(uid="ID1")
+
+        mock_url = "https://api.spond.com/core/v1/sponds/ID1/lineups"
+        mock_get.assert_called_once_with(
+            mock_url,
+            headers={
+                "content-type": "application/json",
+                "Authorization": f"Bearer {mock_token}",
+            },
+        )
+        assert lineups == self.MOCK_LINEUPS
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_lineups__no_lineup_set(self, mock_get, mock_token) -> None:
+        """Test that an event with no line-up returns an empty list."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = True
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=[])
+
+        lineups = await s.get_lineups(uid="ID1")
+
+        assert lineups == []
+
+    @pytest.mark.asyncio
+    @patch("aiohttp.ClientSession.get")
+    async def test_get_formations__happy_path(self, mock_get, mock_token) -> None:
+        """Test that get_formations returns and caches the formation catalogue."""
+        s = Spond(MOCK_USERNAME, MOCK_PASSWORD)
+        s.token = mock_token
+
+        mock_get.return_value.__aenter__.return_value.ok = True
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(
+            return_value=self.MOCK_FORMATIONS
+        )
+
+        formations = await s.get_formations()
+
+        mock_url = "https://api.spond.com/core/v1/lineups/formations"
+        mock_get.assert_called_once_with(
+            mock_url,
+            headers={
+                "content-type": "application/json",
+                "Authorization": f"Bearer {mock_token}",
+            },
+        )
+        assert formations == self.MOCK_FORMATIONS
+        assert s.formations == self.MOCK_FORMATIONS
+
+
 class TestPostMethods:
     MOCK_POSTS: list[JSONDict] = [
         {


### PR DESCRIPTION
## Summary

Adds `get_lineups(uid)` and `get_formations()`, covering Spond's match line-ups — the arrangement of players for a fixture, set in the mobile app.

`get_lineups(uid)` returns one dict per line-up, as an event may hold more than one. Every player entry carries normalised pitch coordinates `x` and `y` in the range 0.0–1.0, with `y` measured from the opponent's goal to the team's own, so the arrangement can be reconstructed rather than just listed. Where a player is assigned to the slot, the entry also carries a `membershipId` (joining to `get_groups()`) and a `playerName`; a formation slot with nobody assigned omits `membershipId` and has an empty or absent `playerName`. `formationId` is absent when players were positioned freely rather than from a template.

`get_formations()` returns the formation catalogue (52 entries, team sizes 5–11) used to resolve `formationId` to a name such as `4-4-2`. It is static and shared across all groups, so it is cached on `self.formations` in line with the other lookups.

Line-ups carry `visibility: "HOSTS_AND_ADMINS_ONLY"`, indicating they are readable only by an event's hosts and admins.

Both are read-only GETs against the existing `core/v1` base URL and need only the usual Bearer token. `examples/lineups.py` prints a text pitch diagram per line-up.

## Notes

- `positions[].name` in the formation catalogue is a localisation key such as `lineup_football_goalkeeper`, not a display string. Documented in the docstring.
- Neither new method checks `r.ok`, following `get_profile`, `get_groups` and `get_event_attendance_xlsx`. The file is split on this — `get_events` and `get_posts` do check. Happy to add the check if you'd prefer.
- Neither endpoint is documented by Spond, so the same no-guarantees caveat as the rest of the library applies.
